### PR TITLE
Change externalId to true for timestream asset id

### DIFF
--- a/src/modules/timestream_telemetry/component-types/timestream_component_type.json
+++ b/src/modules/timestream_telemetry/component-types/timestream_component_type.json
@@ -23,7 +23,7 @@
             "dataType": {
                 "type": "STRING"
             },
-            "isExternalId": false,
+            "isExternalId": true,
             "isStoredExternally": false,
             "isTimeSeries": false,
             "isRequiredInEntity": true


### PR DESCRIPTION
*Issue #, if available:* timestreamAssetId's ExternalId should be set to true instead of false

*Description of changes:*

Changed the json file

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
