### PR TITLE
Improve sitewise components clean up

### DIFF
--- a/src/modules/insights/install_insights_module.py
+++ b/src/modules/insights/install_insights_module.py
@@ -9,9 +9,14 @@ import json
 import argparse
 import sys
 import os
+from enum import Enum
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '../../modules'))
 from sitewise.lib.util.SiteWiseTelemetryUtils import SiteWiseTelemetryImporter
+
+class UpdateType(Enum):
+    CREATE = 'CREATE'
+    DELETE = 'DELETE'
 
 def parse_args():
     parser = argparse.ArgumentParser( description='Imports the Simulation content into a specified workspace.')
@@ -67,30 +72,35 @@ def main():
     def create_sitewise_asset_for_insights(sitewise_model_id, asset_name):
         asset = sitewiseImporter.create_asset(asset_name, sitewise_model_id)
         return asset['assetId']
-
-    def update_entity_with_sitewise_components(entity_id, component_name, asset_id, asset_model_id):
-        try:
-            update_entity = iottwinmaker.update_entity(
-                componentUpdates={
-                    component_name: {
-                        "updateType": "CREATE",
-                        "componentTypeId": "com.amazon.iotsitewise.connector",
-                        "propertyUpdates": {
-                            "sitewiseAssetId": {
-                                "updateType": "UPDATE",
-                                "value": {
-                                    "stringValue": asset_id
-                                }
-                            },
-                            "sitewiseAssetModelId": {
-                                "updateType": "UPDATE",
-                                "value": {
-                                    "stringValue": asset_model_id
-                                }
-                            }
-                        }
+    
+    def get_sitewise_component_updates(update_type: UpdateType, component_name, asset_id, asset_model_id):
+        component_updates = {
+            component_name: {
+                "updateType": update_type.value,
+                "componentTypeId": "com.amazon.iotsitewise.connector"
+            }
+        }
+        if update_type is UpdateType.CREATE:
+            component_updates[component_name]['propertyUpdates'] = {
+                "sitewiseAssetId": {
+                    "updateType": "UPDATE",
+                    "value": {
+                        "stringValue": asset_id
                     }
                 },
+                "sitewiseAssetModelId": {
+                    "updateType": "UPDATE",
+                    "value": {
+                        "stringValue": asset_model_id
+                    }
+                }
+            }
+        return component_updates
+
+    def update_entity_with_sitewise_components(entity_id, component_updates):
+        try:
+            update_entity = iottwinmaker.update_entity(
+                componentUpdates = component_updates,
                 entityId = entity_id,
                 workspaceId = workspace_id)
             print(update_entity)
@@ -101,7 +111,7 @@ def main():
                 state = entity_description['status']['state']
             print('Updating finished')
         except Exception as e:
-            if 'Component '+ component_name + ' in entity ' + entity_id + ' in workspace' in str(e):
+            if list(component_updates.keys())[0] + ' in entity ' + entity_id + ' in workspace' in str(e):
                 print("entity updated")
             else:
                 raise e
@@ -133,7 +143,7 @@ def main():
             for mixer_name in mixers:
                 mixer_entity_id = mixers[mixer_name]
                 simulation_sitewise_asset_id = create_sitewise_asset_for_insights(simulation_sitewise_model_id, f'{workspace_id}_{mixer_name}_Simulation_Output')
-                update_entity_with_sitewise_components(mixer_entity_id, 'PowerSimulationOutputComponent', simulation_sitewise_asset_id, simulation_sitewise_model_id)
+                update_entity_with_sitewise_components(mixer_entity_id, get_sitewise_component_updates(UpdateType.CREATE, POWER_SIMULATION_COMPONENT_NAME, simulation_sitewise_asset_id, simulation_sitewise_model_id))
 
         # Import SiteWise component for storing Anomaly Detection Output.
         if args.import_anomaly_detection_sitewise or args.import_all:
@@ -141,7 +151,7 @@ def main():
             for mixer_name in mixers:
                 mixer_entity_id = mixers[mixer_name]
                 anomaly_detection_sitewise_asset_id = create_sitewise_asset_for_insights(anomaly_detection_sitewise_model_id, f'{workspace_id}_{mixer_name}_Anomaly_Detection_Output')
-                update_entity_with_sitewise_components(mixer_entity_id, 'AnomalyDetectionOutputComponent', anomaly_detection_sitewise_asset_id, anomaly_detection_sitewise_model_id)
+                update_entity_with_sitewise_components(mixer_entity_id, get_sitewise_component_updates(UpdateType.CREATE, ANOMALY_DETECTION_COMPONENT_NAME, anomaly_detection_sitewise_asset_id, anomaly_detection_sitewise_model_id))
 
     def start_kda_app(zeppelin_app_name):
         ## START
@@ -211,9 +221,18 @@ def main():
         if args.delete_simulation_sitewise or args.delete_all:
             print('Deleting sitewise data for simulation...')
             sitewiseImporter.cleanup_sitewise(simulation_output_asset_model_name)
+            print('Deleting sitewise components for simulation...')
+            for mixer_name in mixers:
+                mixer_entity_id = mixers[mixer_name]
+                update_entity_with_sitewise_components(mixer_entity_id, get_sitewise_component_updates(UpdateType.DELETE, POWER_SIMULATION_COMPONENT_NAME, None, None))
+
         if args.delete_anomaly_detection_sitewise or args.delete_all:
             print('Deleting sitewise data for anomaly detection...')
             sitewiseImporter.cleanup_sitewise(anomaly_detection_output_asset_model_name)
+            print('Deleting sitewise components for anomaly detection...')
+            for mixer_name in mixers:
+                mixer_entity_id = mixers[mixer_name]
+                update_entity_with_sitewise_components(mixer_entity_id, get_sitewise_component_updates(UpdateType.DELETE, ANOMALY_DETECTION_COMPONENT_NAME, None, None))
 
     def get_zepplin_app_name():
         cfn_stack_description = cfn_client.describe_stacks(StackName=args.kda_stack_name)
@@ -259,6 +278,7 @@ def main():
 
     mixers = get_mixer_entities()
 
+    POWER_SIMULATION_COMPONENT_NAME, ANOMALY_DETECTION_COMPONENT_NAME = ('PowerSimulationOutputComponent', 'AnomalyDetectionOutputComponent')
     import_sitewise_components(mixers)
 
     start_kda_app(zeppelin_app_name)


### PR DESCRIPTION
*Issue #, if available:*
Current SiteWise clean up does not delete components in entity, which prevents users to recreate SiteWise resources

*Description of changes:*

1. Refactor the logic for update entity to unify create / delete components
2. Add SiteWise components delete logic

*Tests*
Tested on both single-mixer & multi-mixer
import -> delete -> re-import -> test in Zeplin notebook


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
