### PR TITLE
Fix UDQ query for SiteWise addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ In this section we'll add SiteWise assets and telemetry, and then update the Coo
    ```
    aws iottwinmaker get-property-value-history \
      --region $AWS_DEFAULT_REGION \
-     --cli-input-json '{"componentName": "WaterTankVolume","endTime": "2022-11-01T00:00:00Z","entityId": "WaterTank_ab5e8bc0-5c8f-44d8-b0a9-bef9c8d2cfab","orderByTime": "ASCENDING","selectedProperties": ["tankVolume1"],"startTime": "2021-11-01T00:00:00Z","workspaceId": "'${WORKSPACE_ID}'"}'
+     --cli-input-json '{"componentName": "WaterTankVolume","endDateTime": "2022-11-01T00:00:00Z","entityId": "WaterTank_ab5e8bc0-5c8f-44d8-b0a9-bef9c8d2cfab","orderByTime": "ASCENDING","selectedProperties": ["tankVolume1"],"startDateTime": "2021-11-01T00:00:00Z","workspaceId": "'${WORKSPACE_ID}'"}'
    ```
 
 ### S3 Document Connector


### PR DESCRIPTION
Running the command in step 3 of the [Sitewise Add-on](https://github.com/aws-samples/aws-iot-twinmaker-samples#sitewise-connector) gives the error message:
```
Parameter validation failed:
Missing required parameter in input: "endDateTime"
Missing required parameter in input: "startDateTime"
Unknown parameter in input: "endTime", must be one of: componentName, componentTypeId, endDateTime, entityId, interpolation, maxResults, nextToken, orderByTime, propertyFilters, selectedProperties, startDateTime, workspaceId
Unknown parameter in input: "startTime", must be one of: componentName, componentTypeId, endDateTime, entityId, interpolation, maxResults, nextToken, orderByTime, propertyFilters, selectedProperties, startDateTime, workspaceId
```

Changing the command to use `startDateTime` and `endDateTime` instead og `startTime` and `endTime` seems to fix this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
