### PR TITLE
Removed propertyName from externalIdProperty

### DIFF
--- a/src/libs/udq_helper_utils/udq_utils/udq_models.py
+++ b/src/libs/udq_helper_utils/udq_utils/udq_models.py
@@ -9,11 +9,11 @@ from typing import List
 
 class EntityComponentPropertyRef():
     """
-    Represents a unique entity-component-property reference to a property in AWS IoT TwinMaker
-    consists of an entityId, componentName, and propertyName
+    Represents an entity-component-property reference that uniquely identifies an AWS IoT TwinMaker property
+    Consists of an entityId, componentName, and propertyName
     """
 
-    def __init__(self, property_name: str, entity_id: str = None, component_name: str = None):
+    def __init__(self, entity_id: str, component_name: str, property_name: str):
         self.entity_id = entity_id
         self.component_name = component_name
         self.property_name = property_name
@@ -24,32 +24,47 @@ class EntityComponentPropertyRef():
     def __eq__(self, other):
         return (self.entity_id, self.component_name, self.property_name) == (other.entity_id, other.component_name, other.property_name)
 
+class ExternalIdPropertyRef():
+    """
+    Represents an externalIdProperty reference that uniquely identifies an AWS IoT TwinMaker property across entities
+    Consists of a key-value map externalIdProperty and propertyName
+    """
+
+    def __init__(self, external_id_property: dict, property_name: str):
+        self.external_id_property = external_id_property
+        self.property_name = property_name
+
+    def __hash__(self):
+        return hash((json.dumps(self.external_id_property), self.property_name))
+
+    def __eq__(self, other):
+        return (self.external_id_property, self.property_name) == (other.external_id_property, other.property_name)
+
 class IoTTwinMakerReference():
     """
     Represents a unique reference to a property in AWS IoT TwinMaker
-    may include one or both of an EntityComponentPropertyRef or a free-form external_id_property
+    May include an EntityComponentPropertyRef or an ExternalIdPropertyRef
     """
 
-    def __init__(self, ecp: EntityComponentPropertyRef = None, external_id_property: dict = None):
+    def __init__(self, ecp: EntityComponentPropertyRef = None, eip: ExternalIdPropertyRef = None):
         self.ecp = ecp
-        self.external_id_property = external_id_property
+        self.eip = eip
 
     def __hash__(self):
-        return hash((self.ecp, json.dumps(self.external_id_property)))
+        return hash((self.ecp, self.eip))
 
     def __eq__(self, other):
-        return (self.ecp, self.external_id_property) == (other.ecp, other.external_id_property)
+        return (self.ecp, self.eip) == (other.ecp, other.eip)
 
     def serialize(self):
         ret = {}
         if self.ecp:
-            if self.ecp.entity_id:
-                ret['entityId'] = self.ecp.entity_id
-            if self.ecp.component_name:
-                ret['componentName'] = self.ecp.component_name
+            ret['entityId'] = self.ecp.entity_id
+            ret['componentName'] = self.ecp.component_name
             ret['propertyName'] = self.ecp.property_name
-        if self.external_id_property:
-            ret['externalIdProperty'] = self.external_id_property
+        if self.eip:
+            ret['externalIdProperty'] = self.eip.external_id_property
+            ret['propertyName'] = self.eip.property_name
         return ret
 
 

--- a/src/libs/udq_helper_utils/udq_utils/udq_models.py
+++ b/src/libs/udq_helper_utils/udq_utils/udq_models.py
@@ -13,7 +13,7 @@ class EntityComponentPropertyRef():
     consists of an entityId, componentName, and propertyName
     """
 
-    def __init__(self, entity_id: str, component_name: str, property_name: str):
+    def __init__(self, property_name: str, entity_id: str = None, component_name: str = None):
         self.entity_id = entity_id
         self.component_name = component_name
         self.property_name = property_name
@@ -43,12 +43,13 @@ class IoTTwinMakerReference():
     def serialize(self):
         ret = {}
         if self.ecp:
-            ret['entityId'] = self.ecp.entity_id
-            ret['componentName'] = self.ecp.component_name
+            if self.ecp.entity_id:
+                ret['entityId'] = self.ecp.entity_id
+            if self.ecp.component_name:
+                ret['componentName'] = self.ecp.component_name
             ret['propertyName'] = self.ecp.property_name
         if self.external_id_property:
             ret['externalIdProperty'] = self.external_id_property
-            ret['propertyName'] = self.external_id_property['propertyName']
         return ret
 
 

--- a/src/modules/timestream_telemetry/lambda_function/udq_data_reader.py
+++ b/src/modules/timestream_telemetry/lambda_function/udq_data_reader.py
@@ -175,12 +175,12 @@ class TimestreamDataRow(IoTTwinMakerDataRow):
         """
         property_name = self._row_as_dict['measure_name']
         if self._entity_id and self._component_name:
-            return IoTTwinMakerReference(ecp=EntityComponentPropertyRef(self._entity_id, self._component_name, property_name))
+            return IoTTwinMakerReference(ecp=EntityComponentPropertyRef(property_name, self._entity_id, self._component_name))
         else:
-            return IoTTwinMakerReference(external_id_property={
+            return IoTTwinMakerReference(ecp=EntityComponentPropertyRef(property_name), 
+            external_id_property={
                 # special case Alarm and map the externalId to alarm_key
                 'alarm_key' if self._telemetry_asset_type == 'Alarm' else 'telemetryAssetId': self._row_as_dict['TelemetryAssetId'],
-                'propertyName': property_name if property_name != 'Status' else 'alarm_status'  # AWS IoT TwinMaker's alarm component in Grafana expects a particular property name for alarm telemetry
             })
 
     # overrides IoTTwinMakerDataRow.get_timestamp abstractmethod

--- a/src/modules/timestream_telemetry/lambda_function/udq_data_reader.py
+++ b/src/modules/timestream_telemetry/lambda_function/udq_data_reader.py
@@ -10,7 +10,7 @@ import boto3
 
 from udq_utils.udq import SingleEntityReader, MultiEntityReader, IoTTwinMakerDataRow, IoTTwinMakerUdqResponse
 from udq_utils.udq_models import IoTTwinMakerUDQEntityRequest, IoTTwinMakerUDQComponentTypeRequest, OrderBy, IoTTwinMakerReference, \
-    EntityComponentPropertyRef
+    EntityComponentPropertyRef, ExternalIdPropertyRef
 
 from udq_utils.sql_detector import SQLDetector
 
@@ -175,13 +175,13 @@ class TimestreamDataRow(IoTTwinMakerDataRow):
         """
         property_name = self._row_as_dict['measure_name']
         if self._entity_id and self._component_name:
-            return IoTTwinMakerReference(ecp=EntityComponentPropertyRef(property_name, self._entity_id, self._component_name))
+            return IoTTwinMakerReference(ecp=EntityComponentPropertyRef(self._entity_id, self._component_name, property_name))
         else:
-            return IoTTwinMakerReference(ecp=EntityComponentPropertyRef(property_name), 
-            external_id_property={
+            external_id_property = {
                 # special case Alarm and map the externalId to alarm_key
                 'alarm_key' if self._telemetry_asset_type == 'Alarm' else 'telemetryAssetId': self._row_as_dict['TelemetryAssetId'],
-            })
+            }
+            return IoTTwinMakerReference(eip=ExternalIdPropertyRef(external_id_property, property_name))
 
     # overrides IoTTwinMakerDataRow.get_timestamp abstractmethod
     def get_timestamp(self) -> datetime:


### PR DESCRIPTION
Update externalIdProperty in GetPropertyValueHistory response to remove the propertyName key.

*Description of changes:*
Removed "propertyName" from the "externalIdProperty" mapping since it is redundant. The "propertyName" is already shown in the "entityPropertyReference". New Grafana plugin changes assume there is only one key in the "externalIdProperty" which is the key referencing the external data source.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
