### PR TITLE
remove numpy dependency

### DIFF
--- a/src/libs/udq_helper_utils/requirements.txt
+++ b/src/libs/udq_helper_utils/requirements.txt
@@ -1,2 +1,1 @@
 sqlparse==0.4.2
-numpy==1.21.3

--- a/src/libs/udq_helper_utils/udq_utils/sql_detector.py
+++ b/src/libs/udq_helper_utils/udq_utils/sql_detector.py
@@ -1,14 +1,13 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. 2021
 # SPDX-License-Identifier: Apache-2.0
 
-import numpy as np 
 import sqlparse
 
 class SQLDetector:
     
     def getSubTokenCount(self, token):
         count = 0
-        for s in token.flatten():
+        for _ in token.flatten():
             count += 1
         return count
 
@@ -50,7 +49,7 @@ class SQLDetector:
         """
         sampleTokenContext = self.getQueryContext(sampleQuery)
         tokenContext = self.getQueryContext(query)
-        if not np.array_equal(sampleTokenContext, tokenContext):
+        if not sampleTokenContext == tokenContext:
             raise Exception(f'Detected potential injection from query: {query}')
 
     

--- a/src/modules/timestream_telemetry/lambda_function/local.requirements.txt
+++ b/src/modules/timestream_telemetry/lambda_function/local.requirements.txt
@@ -1,6 +1,5 @@
 # boto dependencies make the lambda very large, they are also automatically provided by lambda
 # this file is kept here for installing dependencies locally
-boto3==1.20.17
-botocore==1.21.16
-numpy==1.21.3
+boto3==1.21.40
+botocore==1.24.40
 sqlparse==0.4.2


### PR DESCRIPTION
*Issue #, if available:*
#72 #73 
*Description of changes:*
The new numpy major version 1.22.0 does not support python 3.7 anymore. But the lambda function layer only supports python 3.7. Since numpy is only used once in the library, remove it to mitigate the security issue

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
