### PR TITLE
Update package versions and fix critical vulnerability issue.

### DIFF
--- a/src/modules/sitewise/cdk/package.json
+++ b/src/modules/sitewise/cdk/package.json
@@ -11,21 +11,21 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "1.130.0",
+    "@aws-cdk/assert": "1.160.0",
     "@types/jest": "^26.0.10",
     "@types/node": "10.17.27",
-    "aws-cdk": "1.130.0",
+    "aws-cdk": "1.160.0",
     "jest": "^26.4.2",
     "ts-jest": "^26.2.0",
     "ts-node": "^9.0.0",
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-iam": "^1.132.0",
-    "@aws-cdk/aws-lambda": "^1.132.0",
-    "@aws-cdk/aws-stepfunctions": "^1.132.0",
-    "@aws-cdk/aws-stepfunctions-tasks": "^1.132.0",
-    "@aws-cdk/core": "^1.130.0",
+    "@aws-cdk/aws-iam": "^1.160.0",
+    "@aws-cdk/aws-lambda": "^1.160.0",
+    "@aws-cdk/aws-stepfunctions": "^1.160.0",
+    "@aws-cdk/aws-stepfunctions-tasks": "^1.160.0",
+    "@aws-cdk/core": "^1.160.0",
     "source-map-support": "^0.5.16"
   }
 }


### PR DESCRIPTION
Update aws-cdk/* related packages to 1.160.0

*Issue #, if available:*
Current package version found 1 critical vulnerability under:
aws-cdk > proxy-agent > pac-proxy-agent > pac-resolver > degenerator > vm2
critical: Sandbox bypass in vm2

*Description of changes:*
Update aws-cdk/* related packages to 1.160.0


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
