### PR TITLE
Update sitewise README.md

### DIFF
--- a/src/modules/sitewise/README.md
+++ b/src/modules/sitewise/README.md
@@ -9,7 +9,6 @@ Check out the latest code from https://github.com/aws-samples/aws-iot-twinmaker-
 
 ## Execute as stand-alone script
 ```
-export AWS_ENDPOINT=<Specific AWS endpoint> ## OR beta or prod or whichever environment
 export IoTTwinMakerHome=<Directory where your checked out the code>
 export PYTHONPATH=.:${IoTTwinMakerHome}/src/modules/sitewise/sync-connector-lambda:${IoTTwinMakerHome}/src/libs/connector_utils/python/:$PYTHONPATH # where IoTTwinMakerHome is the directory where you checked out the code.
 ```


### PR DESCRIPTION
remove AWS_ENDPOINT config in Migrating SiteWise instruction as it is not required anymore.

*Issue #, if available:*

*Description of changes:*
Setting the AWS_ENDPOINT is not needed anymore and setting it as in the README instruction will always throw an error "ValueError: Invalid endpoint" even if the the endpoint is correct. This PR is a remedy to update the instructions and once the AWS_ENDPOINT is not in the environment variables the script run as expected. This PR doesn't provide a fix nor a root cause. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
