### PR TITLE
update sample Lambda functions with `iottwinmaker` prefix

### DIFF
--- a/src/modules/s3/cdk/lib/cdk-stack.ts
+++ b/src/modules/s3/cdk/lib/cdk-stack.ts
@@ -21,6 +21,7 @@ export class CdkStack extends Stack {
     s3UdqRole.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName("AmazonS3ReadOnlyAccess"))
 
     const s3ReaderUDQ = new PythonFunction(this, 's3ReaderUDQ', {
+      functionName: `iottwinmaker-${this.stackName}-s3ReaderUDQ`,
       entry: path.join(__dirname, '..', '..', 'lambda_function'),
       layers: [
         new PythonLayerVersion(this, 'udq_utils_layer', {

--- a/src/modules/timestream_telemetry/cdk/lib/timestream_telemetry_lambdas-stack.ts
+++ b/src/modules/timestream_telemetry/cdk/lib/timestream_telemetry_lambdas-stack.ts
@@ -41,6 +41,7 @@ export class TimestreamTelemetryCdkLambdasStack extends Stack {
 
       // udq reader lambda
       const timestreamReaderUDQ = new PythonFunction(this, 'timestreamReaderUDQ', {
+        functionName: `iottwinmaker-${this.stackName}-tsDataReader`,
         entry: path.join(__dirname, '..', '..', 'lambda_function'),
         layers: [
           new PythonLayerVersion(this, 'udq_utils_layer', {


### PR DESCRIPTION
To align with auto-generated workspace permission policies from updated IoT TwinMaker console

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
