### PR TITLE
Update dev server to enable https and port 8080 to better support Clo…

### DIFF
--- a/src/workspaces/cookiefactoryv2/CookieFactoryDemo/webpack.dev.js
+++ b/src/workspaces/cookiefactoryv2/CookieFactoryDemo/webpack.dev.js
@@ -11,8 +11,9 @@ export default merge(common, {
   mode: 'development',
 
   devServer: {
+    https: true,
     hot: true,
-    port: 5000,
+    port: 8080,
     static: './public/'
   },
 

--- a/src/workspaces/cookiefactoryv2/README.md
+++ b/src/workspaces/cookiefactoryv2/README.md
@@ -161,8 +161,8 @@ Note: These instructions have primarily been tested for OSX/Linux/WSL environmen
     npm run dev
     ```
 
-1.  Navigate to `localhost:5000` to view the application, which may take a minute to load the first time.
-    - **Note: set the localhost port to your preference in `webpack.dev.js`. Defaults to `5000`.**
+1.  Navigate to `https://localhost:8080` to view the application, which may take a minute to load the first time.
+    - **Note: set the localhost port to your preference in `webpack.dev.js`. Defaults to `8080`.**
 
 ## Cleanup
 


### PR DESCRIPTION
*Description of changes:* Update Cookie Factory v2 web application dev server to enable https and port 8080 to better support Cloud9 out of the box.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
