### PR TITLE
Bump @iot-app-kit dependencies from 5.5.1 to 5.7.0, fixes SceneViewer unmount bug

### DIFF
--- a/src/workspaces/cookiefactoryv2/CookieFactoryDemo/package-lock.json
+++ b/src/workspaces/cookiefactoryv2/CookieFactoryDemo/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@amzn/cookie-factory-demo-v2",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@amzn/cookie-factory-demo-v2",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "dependencies": {
         "@aws-sdk/client-cognito-identity": "3.252.0",
         "@aws-sdk/client-iottwinmaker": "3.252.0",
         "@aws-sdk/credential-provider-cognito-identity": "3.252.0",
-        "@iot-app-kit/react-components": "5.5.1",
-        "@iot-app-kit/scene-composer": "5.5.1",
-        "@iot-app-kit/source-iottwinmaker": "5.5.1",
+        "@iot-app-kit/react-components": "5.7.0",
+        "@iot-app-kit/scene-composer": "5.7.0",
+        "@iot-app-kit/source-iottwinmaker": "5.7.0",
         "amazon-cognito-identity-js": "6.1.2",
         "cytoscape": "3.23.0",
         "immer": "9.0.19",
@@ -313,45 +313,45 @@
       }
     },
     "node_modules/@aws-sdk/client-iot-events": {
-      "version": "3.281.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-iot-events/-/client-iot-events-3.281.0.tgz",
-      "integrity": "sha512-uRX8rE6zOVXxa0UOVm/KzfUhopzwsYBL2A/62f9NaE4XEV7vwLm6Xpw6HGDUdmmV3Wjc/qPOl9DM2L8pWanEiQ==",
+      "version": "3.319.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-iot-events/-/client-iot-events-3.319.0.tgz",
+      "integrity": "sha512-kwIN83SuGJ55zzvQEzFJBCmbfJOvf24a4pBTBFXcKNyxn3akQXypY9rvTrnDDBuN1MenO/OJcuA9/E1WOLfjpA==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.281.0",
-        "@aws-sdk/config-resolver": "3.272.0",
-        "@aws-sdk/credential-provider-node": "3.281.0",
-        "@aws-sdk/fetch-http-handler": "3.272.0",
-        "@aws-sdk/hash-node": "3.272.0",
-        "@aws-sdk/invalid-dependency": "3.272.0",
-        "@aws-sdk/middleware-content-length": "3.272.0",
-        "@aws-sdk/middleware-endpoint": "3.272.0",
-        "@aws-sdk/middleware-host-header": "3.278.0",
-        "@aws-sdk/middleware-logger": "3.272.0",
-        "@aws-sdk/middleware-recursion-detection": "3.272.0",
-        "@aws-sdk/middleware-retry": "3.272.0",
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/middleware-signing": "3.272.0",
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/middleware-user-agent": "3.272.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/node-http-handler": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/smithy-client": "3.279.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-        "@aws-sdk/util-defaults-mode-node": "3.279.0",
-        "@aws-sdk/util-endpoints": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "@aws-sdk/util-user-agent-browser": "3.272.0",
-        "@aws-sdk/util-user-agent-node": "3.272.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/client-sts": "3.319.0",
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/credential-provider-node": "3.319.0",
+        "@aws-sdk/fetch-http-handler": "3.310.0",
+        "@aws-sdk/hash-node": "3.310.0",
+        "@aws-sdk/invalid-dependency": "3.310.0",
+        "@aws-sdk/middleware-content-length": "3.310.0",
+        "@aws-sdk/middleware-endpoint": "3.310.0",
+        "@aws-sdk/middleware-host-header": "3.310.0",
+        "@aws-sdk/middleware-logger": "3.310.0",
+        "@aws-sdk/middleware-recursion-detection": "3.310.0",
+        "@aws-sdk/middleware-retry": "3.310.0",
+        "@aws-sdk/middleware-serde": "3.310.0",
+        "@aws-sdk/middleware-signing": "3.310.0",
+        "@aws-sdk/middleware-stack": "3.310.0",
+        "@aws-sdk/middleware-user-agent": "3.319.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/node-http-handler": "3.310.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/smithy-client": "3.316.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+        "@aws-sdk/util-defaults-mode-node": "3.316.0",
+        "@aws-sdk/util-endpoints": "3.319.0",
+        "@aws-sdk/util-retry": "3.310.0",
+        "@aws-sdk/util-user-agent-browser": "3.310.0",
+        "@aws-sdk/util-user-agent-node": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -434,387 +434,394 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/abort-controller": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.272.0.tgz",
-      "integrity": "sha512-s2TV3phapcTwZNr4qLxbfuQuE9ZMP4RoJdkvRRCkKdm6jslsWLJf2Zlcxti/23hOlINUMYv2iXE2pftIgWGdpg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.310.0.tgz",
+      "integrity": "sha512-v1zrRQxDLA1MdPim159Vx/CPHqsB4uybSxRi1CnfHO5ZjHryx3a5htW2gdGAykVCul40+yJXvfpufMrELVxH+g==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/client-sso": {
-      "version": "3.281.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.281.0.tgz",
-      "integrity": "sha512-3RvO5zClQhu37w9VMLoHPGk58S3y8Spb7XX8rW51bm5TUglYQskQ0X2VLEUW/7ZGx/peokHws9Z9+w5yGq5sdA==",
+      "version": "3.319.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.319.0.tgz",
+      "integrity": "sha512-g46KgAjRiYBS8Oi85DPwSAQpt+Hgmw/YFgGVwZqMfTL70KNJwLFKRa5D9UocQd7t7OjPRdKF7g0Gp5peyAK9dw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.272.0",
-        "@aws-sdk/fetch-http-handler": "3.272.0",
-        "@aws-sdk/hash-node": "3.272.0",
-        "@aws-sdk/invalid-dependency": "3.272.0",
-        "@aws-sdk/middleware-content-length": "3.272.0",
-        "@aws-sdk/middleware-endpoint": "3.272.0",
-        "@aws-sdk/middleware-host-header": "3.278.0",
-        "@aws-sdk/middleware-logger": "3.272.0",
-        "@aws-sdk/middleware-recursion-detection": "3.272.0",
-        "@aws-sdk/middleware-retry": "3.272.0",
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/middleware-user-agent": "3.272.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/node-http-handler": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/smithy-client": "3.279.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-        "@aws-sdk/util-defaults-mode-node": "3.279.0",
-        "@aws-sdk/util-endpoints": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "@aws-sdk/util-user-agent-browser": "3.272.0",
-        "@aws-sdk/util-user-agent-node": "3.272.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/fetch-http-handler": "3.310.0",
+        "@aws-sdk/hash-node": "3.310.0",
+        "@aws-sdk/invalid-dependency": "3.310.0",
+        "@aws-sdk/middleware-content-length": "3.310.0",
+        "@aws-sdk/middleware-endpoint": "3.310.0",
+        "@aws-sdk/middleware-host-header": "3.310.0",
+        "@aws-sdk/middleware-logger": "3.310.0",
+        "@aws-sdk/middleware-recursion-detection": "3.310.0",
+        "@aws-sdk/middleware-retry": "3.310.0",
+        "@aws-sdk/middleware-serde": "3.310.0",
+        "@aws-sdk/middleware-stack": "3.310.0",
+        "@aws-sdk/middleware-user-agent": "3.319.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/node-http-handler": "3.310.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/smithy-client": "3.316.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+        "@aws-sdk/util-defaults-mode-node": "3.316.0",
+        "@aws-sdk/util-endpoints": "3.319.0",
+        "@aws-sdk/util-retry": "3.310.0",
+        "@aws-sdk/util-user-agent-browser": "3.310.0",
+        "@aws-sdk/util-user-agent-node": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.281.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.281.0.tgz",
-      "integrity": "sha512-P6zf9pDuxApVoCYStAg7L8BU9AcWI8PxfLSX4r2WnmcQropxzPJ3op1j9nvbwwBDMFWephijVY4AVp8MqPcPyg==",
+      "version": "3.319.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.319.0.tgz",
+      "integrity": "sha512-GJBgT/tephRZY3oTbDBMv+G9taoqKUIvGPn+7shmzz2P1SerutsRSfKfDXV+VptPNRoGmjjCLPmWjMFYbFKILQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.272.0",
-        "@aws-sdk/fetch-http-handler": "3.272.0",
-        "@aws-sdk/hash-node": "3.272.0",
-        "@aws-sdk/invalid-dependency": "3.272.0",
-        "@aws-sdk/middleware-content-length": "3.272.0",
-        "@aws-sdk/middleware-endpoint": "3.272.0",
-        "@aws-sdk/middleware-host-header": "3.278.0",
-        "@aws-sdk/middleware-logger": "3.272.0",
-        "@aws-sdk/middleware-recursion-detection": "3.272.0",
-        "@aws-sdk/middleware-retry": "3.272.0",
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/middleware-user-agent": "3.272.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/node-http-handler": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/smithy-client": "3.279.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-        "@aws-sdk/util-defaults-mode-node": "3.279.0",
-        "@aws-sdk/util-endpoints": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "@aws-sdk/util-user-agent-browser": "3.272.0",
-        "@aws-sdk/util-user-agent-node": "3.272.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/fetch-http-handler": "3.310.0",
+        "@aws-sdk/hash-node": "3.310.0",
+        "@aws-sdk/invalid-dependency": "3.310.0",
+        "@aws-sdk/middleware-content-length": "3.310.0",
+        "@aws-sdk/middleware-endpoint": "3.310.0",
+        "@aws-sdk/middleware-host-header": "3.310.0",
+        "@aws-sdk/middleware-logger": "3.310.0",
+        "@aws-sdk/middleware-recursion-detection": "3.310.0",
+        "@aws-sdk/middleware-retry": "3.310.0",
+        "@aws-sdk/middleware-serde": "3.310.0",
+        "@aws-sdk/middleware-stack": "3.310.0",
+        "@aws-sdk/middleware-user-agent": "3.319.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/node-http-handler": "3.310.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/smithy-client": "3.316.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+        "@aws-sdk/util-defaults-mode-node": "3.316.0",
+        "@aws-sdk/util-endpoints": "3.319.0",
+        "@aws-sdk/util-retry": "3.310.0",
+        "@aws-sdk/util-user-agent-browser": "3.310.0",
+        "@aws-sdk/util-user-agent-node": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/client-sts": {
-      "version": "3.281.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.281.0.tgz",
-      "integrity": "sha512-w8QomyhCVEArRcXgOkjbofiS/PLEKWRAyYBovjMS1cGhns2ZYJXFgHNgr3VGE54TghUc5dR1CqKuBKKM4ThrgA==",
+      "version": "3.319.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.319.0.tgz",
+      "integrity": "sha512-PRGGKCSKtyM3x629J9j4DMsH1cQT8UGW+R67u9Q5HrMK05gfjpmg+X1DQ3pgve4D8MI4R/Cm3NkYl2eUTbQHQg==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.272.0",
-        "@aws-sdk/credential-provider-node": "3.281.0",
-        "@aws-sdk/fetch-http-handler": "3.272.0",
-        "@aws-sdk/hash-node": "3.272.0",
-        "@aws-sdk/invalid-dependency": "3.272.0",
-        "@aws-sdk/middleware-content-length": "3.272.0",
-        "@aws-sdk/middleware-endpoint": "3.272.0",
-        "@aws-sdk/middleware-host-header": "3.278.0",
-        "@aws-sdk/middleware-logger": "3.272.0",
-        "@aws-sdk/middleware-recursion-detection": "3.272.0",
-        "@aws-sdk/middleware-retry": "3.272.0",
-        "@aws-sdk/middleware-sdk-sts": "3.272.0",
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/middleware-signing": "3.272.0",
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/middleware-user-agent": "3.272.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/node-http-handler": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/smithy-client": "3.279.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-        "@aws-sdk/util-defaults-mode-node": "3.279.0",
-        "@aws-sdk/util-endpoints": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "@aws-sdk/util-user-agent-browser": "3.272.0",
-        "@aws-sdk/util-user-agent-node": "3.272.0",
-        "@aws-sdk/util-utf8": "3.254.0",
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/credential-provider-node": "3.319.0",
+        "@aws-sdk/fetch-http-handler": "3.310.0",
+        "@aws-sdk/hash-node": "3.310.0",
+        "@aws-sdk/invalid-dependency": "3.310.0",
+        "@aws-sdk/middleware-content-length": "3.310.0",
+        "@aws-sdk/middleware-endpoint": "3.310.0",
+        "@aws-sdk/middleware-host-header": "3.310.0",
+        "@aws-sdk/middleware-logger": "3.310.0",
+        "@aws-sdk/middleware-recursion-detection": "3.310.0",
+        "@aws-sdk/middleware-retry": "3.310.0",
+        "@aws-sdk/middleware-sdk-sts": "3.310.0",
+        "@aws-sdk/middleware-serde": "3.310.0",
+        "@aws-sdk/middleware-signing": "3.310.0",
+        "@aws-sdk/middleware-stack": "3.310.0",
+        "@aws-sdk/middleware-user-agent": "3.319.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/node-http-handler": "3.310.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/smithy-client": "3.316.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+        "@aws-sdk/util-defaults-mode-node": "3.316.0",
+        "@aws-sdk/util-endpoints": "3.319.0",
+        "@aws-sdk/util-retry": "3.310.0",
+        "@aws-sdk/util-user-agent-browser": "3.310.0",
+        "@aws-sdk/util-user-agent-node": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
         "fast-xml-parser": "4.1.2",
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/config-resolver": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.272.0.tgz",
-      "integrity": "sha512-Dr4CffRVNsOp3LRNdpvcH6XuSgXOSLblWliCy/5I86cNl567KVMxujVx6uPrdTXYs2h1rt3MNl6jQGnAiJeTbw==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.310.0.tgz",
+      "integrity": "sha512-8vsT+/50lOqfDxka9m/rRt6oxv1WuGZoP8oPMk0Dt+TxXMbAzf4+rejBgiB96wshI1k3gLokYRjSQZn+dDtT8g==",
       "dependencies": {
-        "@aws-sdk/signature-v4": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-config-provider": "3.310.0",
+        "@aws-sdk/util-middleware": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.272.0.tgz",
-      "integrity": "sha512-QI65NbLnKLYHyTYhXaaUrq6eVsCCrMUb05WDA7+TJkWkjXesovpjc8vUKgFiLSxmgKmb2uOhHNcDyObKMrYQFw==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.310.0.tgz",
+      "integrity": "sha512-vvIPQpI16fj95xwS7M3D48F7QhZJBnnCgB5lR+b7So+vsG9ibm1mZRVGzVpdxCvgyOhHFbvrby9aalNJmmIP1A==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.272.0.tgz",
-      "integrity": "sha512-wwAfVY1jTFQEfxVfdYD5r5ieYGl+0g4nhekVxNMqE8E1JeRDd18OqiwAflzpgBIqxfqvCUkf+vl5JYyacMkNAQ==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.310.0.tgz",
+      "integrity": "sha512-baxK7Zp6dai5AGW01FIW27xS2KAaPUmKLIXv5SvFYsUgXXvNW55im4uG3b+2gA0F7V+hXvVBH08OEqmwW6we5w==",
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.281.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.281.0.tgz",
-      "integrity": "sha512-H99nhMhHImQKgNhHKYc6usTS6UK8KzCcVGpILLVTuP97YlrYAMFAVstA3Xk6mZ28JAbHVXvI6vJjkMNOzCSKCA==",
+      "version": "3.319.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.319.0.tgz",
+      "integrity": "sha512-pzx388Fw1KlSgmIMUyRY8DJVYM3aXpwzjprD4RiQVPJeAI+t7oQmEvd2FiUZEuHDjWXcuonxgU+dk7i7HUk/HQ==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.272.0",
-        "@aws-sdk/credential-provider-imds": "3.272.0",
-        "@aws-sdk/credential-provider-process": "3.272.0",
-        "@aws-sdk/credential-provider-sso": "3.281.0",
-        "@aws-sdk/credential-provider-web-identity": "3.272.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/credential-provider-env": "3.310.0",
+        "@aws-sdk/credential-provider-imds": "3.310.0",
+        "@aws-sdk/credential-provider-process": "3.310.0",
+        "@aws-sdk/credential-provider-sso": "3.319.0",
+        "@aws-sdk/credential-provider-web-identity": "3.310.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.281.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.281.0.tgz",
-      "integrity": "sha512-jhddd+lJp8G8hBJ+6glmXjfWJT3nxiE1aliH3fBC4RR3D+1kRXc99Xg6mbUb8bm+GrVZ4gzfiqSgg+ByKjd7xA==",
+      "version": "3.319.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.319.0.tgz",
+      "integrity": "sha512-DS4a0Rdd7ZtMshoeE+zuSgbC05YBcdzd0h89u/eX+1Yqx+HCjeb8WXkbXsz0Mwx8q9TE04aS8f6Bw9J4x4mO5g==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.272.0",
-        "@aws-sdk/credential-provider-imds": "3.272.0",
-        "@aws-sdk/credential-provider-ini": "3.281.0",
-        "@aws-sdk/credential-provider-process": "3.272.0",
-        "@aws-sdk/credential-provider-sso": "3.281.0",
-        "@aws-sdk/credential-provider-web-identity": "3.272.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/credential-provider-env": "3.310.0",
+        "@aws-sdk/credential-provider-imds": "3.310.0",
+        "@aws-sdk/credential-provider-ini": "3.319.0",
+        "@aws-sdk/credential-provider-process": "3.310.0",
+        "@aws-sdk/credential-provider-sso": "3.319.0",
+        "@aws-sdk/credential-provider-web-identity": "3.310.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.272.0.tgz",
-      "integrity": "sha512-hiCAjWWm2PeBFp5cjkxqyam/XADjiS+e7GzwC34TbZn3LisS0uoweLojj9tD11NnnUhyhbLteUvu5+rotOLwrg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.310.0.tgz",
+      "integrity": "sha512-h73sg6GPMUWC+3zMCbA1nZ2O03nNJt7G96JdmnantiXBwHpRKWW8nBTLzx5uhXn6hTuTaoQRP/P+oxQJKYdMmA==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.281.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.281.0.tgz",
-      "integrity": "sha512-IqJnpXuLpJYoSCf/Rt66/CPVTjfkam3z9+ZvlQJV+VbK+vGj276qEtTmSN3XPZZgF1XbWptvkzIWDszLhHiZmg==",
+      "version": "3.319.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.319.0.tgz",
+      "integrity": "sha512-gAUnWH41lxkIbANXu+Rz5zS0Iavjjmpf3C56vAMT7oaYZ3Cg/Ys5l2SwAucQGOCA2DdS2hDiSI8E+Yhr4F5toA==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.281.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/token-providers": "3.281.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/client-sso": "3.319.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/token-providers": "3.319.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.272.0.tgz",
-      "integrity": "sha512-ImrHMkcgneGa/HadHAQXPwOrX26sAKuB8qlMxZF/ZCM2B55u8deY+ZVkVuraeKb7YsahMGehPFOfRAF6mvFI5Q==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.310.0.tgz",
+      "integrity": "sha512-H4SzuZXILNhK6/IR1uVvsUDZvzc051hem7GLyYghBCu8mU+tq28YhKE8MfSroi6eL2e5Vujloij1OM2EQQkPkw==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.272.0.tgz",
-      "integrity": "sha512-1Qhm9e0RbS1Xf4CZqUbQyUMkDLd7GrsRXWIvm9b86/vgeV8/WnjO3CMue9D51nYgcyQORhYXv6uVjAYCWbUExA==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.310.0.tgz",
+      "integrity": "sha512-Bi9vIwzdkw1zMcvi/zGzlWS9KfIEnAq4NNhsnCxbQ4OoIRU9wvU+WGZdBBhxg0ZxZmpp1j1aZhU53lLjA07MHw==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/querystring-builder": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/querystring-builder": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/hash-node": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.272.0.tgz",
-      "integrity": "sha512-40dwND+iAm3VtPHPZu7/+CIdVJFk2s0cWZt1lOiMPMSXycSYJ45wMk7Lly3uoqRx0uWfFK5iT2OCv+fJi5jTng==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.310.0.tgz",
+      "integrity": "sha512-NvE2fhRc8GRwCXBfDehxVAWCmVwVMILliAKVPAEr4yz2CkYs0tqU51S48x23dtna07H4qHtgpeNqVTthcIQOEQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.272.0.tgz",
-      "integrity": "sha512-ysW6wbjl1Y78txHUQ/Tldj2Rg1BI7rpMO9B9xAF6yAX3mQ7t6SUPQG/ewOGvH2208NBIl3qP5e/hDf0Q6r/1iw==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.310.0.tgz",
+      "integrity": "sha512-1s5RG5rSPXoa/aZ/Kqr5U/7lqpx+Ry81GprQ2bxWqJvWQIJ0IRUwo5pk8XFxbKVr/2a+4lZT/c3OGoBOM1yRRA==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
+      "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.272.0.tgz",
-      "integrity": "sha512-sAbDZSTNmLX+UTGwlUHJBWy0QGQkiClpHwVFXACon+aG0ySLNeRKEVYs6NCPYldw4cj6hveLUn50cX44ukHErw==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.310.0.tgz",
+      "integrity": "sha512-P8tQZxgDt6CAh1wd/W6WPzjc+uWPJwQkm+F7rAwRlM+k9q17HrhnksGDKcpuuLyIhPQYdmOMIkpKVgXGa4avhQ==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/middleware-endpoint": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.272.0.tgz",
-      "integrity": "sha512-Dk3JVjj7SxxoUKv3xGiOeBksvPtFhTDrVW75XJ98Ymv8gJH5L1sq4hIeJAHRKogGiRFq2J73mnZSlM9FVXEylg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.310.0.tgz",
+      "integrity": "sha512-Z+N2vOL8K354/lstkClxLLsr6hCpVRh+0tCMXrVj66/NtKysCEZ/0b9LmqOwD9pWHNiI2mJqXwY0gxNlKAroUg==",
       "dependencies": {
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/signature-v4": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/middleware-serde": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-middleware": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.278.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.278.0.tgz",
-      "integrity": "sha512-oTkF3exy89KE8NgSeXFwD+0H0GRKL2qUw92t3caEj7+4KzU/0m3t7NtKlq2NLRtTJhZ/izYRpV536oogLzGm3g==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.310.0.tgz",
+      "integrity": "sha512-QWSA+46/hXorXyWa61ic2K7qZzwHTiwfk2e9mRRjeIRepUgI3qxFjsYqrWtrOGBjmFmq0pYIY8Bb/DCJuQqcoA==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.272.0.tgz",
-      "integrity": "sha512-u2SQ0hWrFwxbxxYMG5uMEgf01pQY5jauK/LYWgGIvuCmFgiyRQQP3oN7kkmsxnS9MWmNmhbyQguX2NY02s5e9w==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.310.0.tgz",
+      "integrity": "sha512-Lurm8XofrASBRnAVtiSNuDSRsRqPNg27RIFLLsLp/pqog9nFJ0vz0kgdb9S5Z+zw83Mm+UlqOe6D8NTUNp4fVg==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.272.0.tgz",
-      "integrity": "sha512-Gp/eKWeUWVNiiBdmUM2qLkBv+VLSJKoWAO+aKmyxxwjjmWhE0FrfA1NQ1a3g+NGMhRbAfQdaYswRAKsul70ISg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.310.0.tgz",
+      "integrity": "sha512-SuB75/xk/gyue24gkriTwO2jFd7YcUGZDClQYuRejgbXSa3CO0lWyawQtfLcSSEBp9izrEVXuFH24K1eAft5nQ==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.272.0.tgz",
-      "integrity": "sha512-pCGvHM7C76VbO/dFerH+Vwf7tGv7j+e+eGrvhQ35mRghCtfIou/WMfTZlD1TNee93crrAQQVZKjtW3dMB3WCzg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.310.0.tgz",
+      "integrity": "sha512-oTPsRy2W4s+dfxbJPW7Km+hHtv/OMsNsVfThAq8DDYKC13qlr1aAyOqGLD+dpBy2aKe7ss517Sy2HcHtHqm7/g==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/service-error-classification": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-middleware": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "tslib": "^2.3.1",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/service-error-classification": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-middleware": "3.310.0",
+        "@aws-sdk/util-retry": "3.310.0",
+        "tslib": "^2.5.0",
         "uuid": "^8.3.2"
       },
       "engines": {
@@ -822,320 +829,394 @@
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.272.0.tgz",
-      "integrity": "sha512-VvYPg7LrDIjUOWueSzo2wBzcNG7dw+cmzV6zAKaLxf0RC5jeAP4hE0OzDiiZfDrjNghEzgq/V+0NO+LewqYL9Q==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.310.0.tgz",
+      "integrity": "sha512-+5PFwlYNLvLLIfw0ASAoWV/iIF8Zv6R6QGtyP0CclhRSvNjgbQDVnV0g95MC5qvh+GB/Yjlkt8qAjLSPjHfsrQ==",
       "dependencies": {
-        "@aws-sdk/middleware-signing": "3.272.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/signature-v4": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/middleware-signing": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.272.0.tgz",
-      "integrity": "sha512-kW1uOxgPSwtXPB5rm3QLdWomu42lkYpQL94tM1BjyFOWmBLO2lQhk5a7Dw6HkTozT9a+vxtscLChRa6KZe61Hw==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.310.0.tgz",
+      "integrity": "sha512-RNeeTVWSLTaentUeCgQKZhAl+C6hxtwD78cQWS10UymWpQFwbaxztzKUu4UQS5xA2j6PxwPRRUjqa4jcFjfLsg==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.272.0.tgz",
-      "integrity": "sha512-4LChFK4VAR91X+dupqM8fQqYhFGE0G4Bf9rQlVTgGSbi2KUOmpqXzH0/WKE228nKuEhmH8+Qd2VPSAE2JcyAUA==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.310.0.tgz",
+      "integrity": "sha512-f9mKq+XMdW207Af3hKjdTnpNhdtwqWuvFs/ZyXoOkp/g1MY1O6L23Jy6i52m29LxbT4AuNRG1oKODfXM0vYVjQ==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/signature-v4": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-middleware": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/signature-v4": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-middleware": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.272.0.tgz",
-      "integrity": "sha512-jhwhknnPBGhfXAGV5GXUWfEhDFoP/DN8MPCO2yC5OAxyp6oVJ8lTPLkZYMTW5VL0c0eG44dXpF4Ib01V+PlDrQ==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.310.0.tgz",
+      "integrity": "sha512-010O1PD+UAcZVKRvqEusE1KJqN96wwrf6QsqbRM0ywsKQ21NDweaHvEDlds2VHpgmofxkRLRu/IDrlPkKRQrRg==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.272.0.tgz",
-      "integrity": "sha512-Qy7/0fsDJxY5l0bEk7WKDfqb4Os/sCAgFR2zEvrhDtbkhYPf72ysvg/nRUTncmCbo8tOok4SJii2myk8KMfjjw==",
+      "version": "3.319.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.319.0.tgz",
+      "integrity": "sha512-ytaLx2dlR5AdMSne6FuDCISVg8hjyKj+cHU20b2CRA/E/z+XXrLrssp4JrCgizRKPPUep0psMIa22Zd6osTT5Q==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-endpoints": "3.319.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.272.0.tgz",
-      "integrity": "sha512-YYCIBh9g1EQo7hm2l22HX5Yr9RoPQ2RCvhzKvF1n1e8t1QH4iObQrYUtqHG4khcm64Cft8C5MwZmgzHbya5Z6Q==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.310.0.tgz",
+      "integrity": "sha512-T/Pp6htc6hq/Cq+MLNDSyiwWCMVF6GqbBbXKVlO5L8rdHx4sq9xPdoPveZhGWrxvkanjA6eCwUp6E0riBOSVng==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.272.0.tgz",
-      "integrity": "sha512-VrW9PjhhngeyYp4yGYPe5S0vgZH6NwU3Po9xAgayUeE37Inr7LS1YteFMHdpgsUUeNXnh7d06CXqHo1XjtqOKA==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.310.0.tgz",
+      "integrity": "sha512-irv9mbcM9xC2xYjArQF5SYmHBMu4ciMWtGsoHII1nRuFOl9FoT4ffTvEPuLlfC6pznzvKt9zvnm6xXj7gDChKg==",
       "dependencies": {
-        "@aws-sdk/abort-controller": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/querystring-builder": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/abort-controller": "3.310.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/querystring-builder": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/property-provider": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.272.0.tgz",
-      "integrity": "sha512-V1pZTaH5eqpAt8O8CzbItHhOtzIfFuWymvwZFkAtwKuaHpnl7jjrTouV482zoq8AD/fF+VVSshwBKYA7bhidIw==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.310.0.tgz",
+      "integrity": "sha512-3lxDb0akV6BBzmFe4nLPaoliQbAifyWJhuvuDOu7e8NzouvpQXs0275w9LePhhcgjKAEVXUIse05ZW2DLbxo/g==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.272.0.tgz",
-      "integrity": "sha512-4JQ54v5Yn08jspNDeHo45CaSn1CvTJqS1Ywgr79eU6jBExtguOWv6LNtwVSBD9X37v88iqaxt8iu1Z3pZZAJeg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.310.0.tgz",
+      "integrity": "sha512-fgZ1aw/irQtnrsR58pS8ThKOWo57Py3xX6giRvwSgZDEcxHfVzuQjy9yPuV++v04fdmdtgpbGf8WfvAAJ11yXQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.272.0.tgz",
-      "integrity": "sha512-ndo++7GkdCj5tBXE6rGcITpSpZS4PfyV38wntGYAlj9liL1omk3bLZRY6uzqqkJpVHqbg2fD7O2qHNItzZgqhw==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.310.0.tgz",
+      "integrity": "sha512-ZHH8GV/80+pWGo7DzsvwvXR5xVxUHXUvPJPFAkhr6nCf78igdoF8gR10ScFoEKbtEapoNTaZlKHPXxpD8aPG7A==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.272.0.tgz",
-      "integrity": "sha512-5oS4/9n6N1LZW9tI3qq/0GnCuWoOXRgcHVB+AJLRBvDbEe+GI+C/xK1tKLsfpDNgsQJHc4IPQoIt4megyZ/1+A==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.310.0.tgz",
+      "integrity": "sha512-YkIznoP6lsiIUHinx++/lbb3tlMURGGqMpo0Pnn32zYzGrJXA6eC3D0as2EcMjo55onTfuLcIiX4qzXes2MYOA==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.272.0.tgz",
-      "integrity": "sha512-REoltM1LK9byyIufLqx9znhSolPcHQgVHIA2S0zu5sdt5qER4OubkLAXuo4MBbisUTmh8VOOvIyUb5ijZCXq1w==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.310.0.tgz",
+      "integrity": "sha512-PuyC7k3qfIKeH2LCnDwbttMOKq3qAx4buvg0yfnJtQOz6t1AR8gsnAq0CjKXXyfkXwNKWTqCpE6lVNUIkXgsMw==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.272.0.tgz",
-      "integrity": "sha512-lzFPohp5sy2XvwFjZIzLVCRpC0i5cwBiaXmFzXYQZJm6FSCszHO4ax+m9yrtlyVFF/2YPWl+/bzNthy4aJtseA==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.310.0.tgz",
+      "integrity": "sha512-N0q9pG0xSjQwc690YQND5bofm+4nfUviQ/Ppgan2kU6aU0WUq8KwgHJBto/YEEI+VlrME30jZJnxtOvcZJc2XA==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/signature-v4": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.272.0.tgz",
-      "integrity": "sha512-pWxnHG1NqJWMwlhJ6NHNiUikOL00DHROmxah6krJPMPq4I3am2KY2Rs/8ouWhnEXKaHAv4EQhSALJ+7Mq5S4/A==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.310.0.tgz",
+      "integrity": "sha512-1M60P1ZBNAjCFv9sYW29OF6okktaeibWyW3lMXqzoHF70lHBZh+838iUchznXUA5FLabfn4jBFWMRxlAXJUY2Q==",
       "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-middleware": "3.272.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "@aws-sdk/util-middleware": "3.310.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/smithy-client": {
-      "version": "3.279.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.279.0.tgz",
-      "integrity": "sha512-ZcYWUQDGAYN6NXRpJuSn46PetrpPCA6TrDVwP9+3pERzTXZ66npXoG2XhHjNrOXy/Ted5A3OxKrM4/zLu9tK3A==",
+      "version": "3.316.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.316.0.tgz",
+      "integrity": "sha512-6YXOKbRnXeS8r8RWzuL6JMBolDYM5Wa4fD/VY6x/wK78i2xErHOvqzHgyyeLI1MMw4uqyd4wRNJNWC9TMPduXw==",
       "dependencies": {
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/middleware-stack": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/token-providers": {
-      "version": "3.281.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.281.0.tgz",
-      "integrity": "sha512-36Vg/F6Edm7qdjcTeNVON+sK2edgHhmhTtAEjWcuUk5AX/Et+Ate/A2N8HD3nxwlAcgidfnBC9SHYJatbhcEnQ==",
+      "version": "3.319.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.319.0.tgz",
+      "integrity": "sha512-5utg6VL6Pl0uiLUn8ZJPYYxzCb9VRPsgJmGXktRUwq0YlTJ6ABcaxTXwZcC++sjh/qyCQDK5PPLNU5kIBttHMQ==",
       "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.281.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/client-sso-oidc": "3.319.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/types": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.272.0.tgz",
-      "integrity": "sha512-MmmL6vxMGP5Bsi+4wRx4mxYlU/LX6M0noOXrDh/x5FfG7/4ZOar/nDxqDadhJtNM88cuWVHZWY59P54JzkGWmA==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.310.0.tgz",
+      "integrity": "sha512-j8eamQJ7YcIhw7fneUfs8LYl3t01k4uHi4ZDmNRgtbmbmTTG3FZc2MotStZnp3nZB6vLiPF1o5aoJxWVvkzS6A==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/url-parser": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.272.0.tgz",
-      "integrity": "sha512-vX/Tx02PlnQ/Kgtf5TnrNDHPNbY+amLZjW0Z1d9vzAvSZhQ4i9Y18yxoRDIaDTCNVRDjdhV8iuctW+05PB5JtQ==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.310.0.tgz",
+      "integrity": "sha512-mCLnCaSB9rQvAgx33u0DujLvr4d5yEm/W5r789GblwwQnlNXedVu50QRizMLTpltYWyAUoXjJgQnJHmJMaKXhw==",
       "dependencies": {
-        "@aws-sdk/querystring-parser": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/querystring-parser": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/util-base64": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
+      "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
+      "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
+      "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
+      "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
+      "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.279.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.279.0.tgz",
-      "integrity": "sha512-RnchYRrpapTT5Hu23LOfk6e8RMVq0kUzho6xA6TJj1a4uGxkcRMvgzPipCq1P5uHu0mrkQBg9pGPEVNOUs38/Q==",
+      "version": "3.316.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.316.0.tgz",
+      "integrity": "sha512-6FSqLhYmaihtH2n1s4b2rlLW0ABU8N6VZIfzLfe2ING4PF0MzfaMMhnTFUHVXfKCVGoR8yP6iyFTRCyHGVEL1w==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">= 10.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.279.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.279.0.tgz",
-      "integrity": "sha512-A2NB10xReWC+GSnOivKGZ9rnljIZdEP8WMCQQEnA6DJNI19AUFF/O9QJ9y+cHGLKEms7jH86Y99wShdpzAK+Jw==",
+      "version": "3.316.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.316.0.tgz",
+      "integrity": "sha512-dkYy10hdjPSScXXvnjGpZpnJxllkb6ICHgLMwZ4JczLHhPM12T/4PQ758YN8HS+muiYDGX1Bl2z1jd/bMcewBQ==",
       "dependencies": {
-        "@aws-sdk/config-resolver": "3.272.0",
-        "@aws-sdk/credential-provider-imds": "3.272.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/credential-provider-imds": "3.310.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">= 10.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.272.0.tgz",
-      "integrity": "sha512-c4MPUaJt2G6gGpoiwIOqDfUa98c1J63RpYvf/spQEKOtC/tF5Gfqlxuq8FnAl5lHnrqj1B9ZXLLxFhHtDR0IiQ==",
+      "version": "3.319.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.319.0.tgz",
+      "integrity": "sha512-3I64UMoYA2e2++oOUJXRcFtYLpLylnZFRltWfPo1B3dLlf+MIWat9djT+mMus+hW1ntLsvAIVu1hLVePJC0gvw==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
+      "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/util-middleware": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.272.0.tgz",
-      "integrity": "sha512-Abw8m30arbwxqmeMMha5J11ESpHUNmCeSqSzE8/C4B8jZQtHY4kq7f+upzcNIQ11lsd+uzBEzNG3+dDRi0XOJQ==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.310.0.tgz",
+      "integrity": "sha512-FTSUKL/eRb9X6uEZClrTe27QFXUNNp7fxYrPndZwk1hlaOP5ix+MIHBcI7pIiiY/JPfOUmPyZOu+HetlFXjWog==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/util-retry": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.272.0.tgz",
-      "integrity": "sha512-Ngha5414LR4gRHURVKC9ZYXsEJhMkm+SJ+44wlzOhavglfdcKKPUsibz5cKY1jpUV7oKECwaxHWpBB8r6h+hOg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.310.0.tgz",
+      "integrity": "sha512-FwWGhCBLfoivTMUHu1LIn4NjrN9JLJ/aX5aZmbcPIOhZVFJj638j0qDgZXyfvVqBuBZh7M8kGq0Oahy3dp69OA==",
       "dependencies": {
-        "@aws-sdk/service-error-classification": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/service-error-classification": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.272.0.tgz",
-      "integrity": "sha512-Lp5QX5bH6uuwBlIdr7w7OAcAI50ttyskb++yUr9i+SPvj6RI2dsfIBaK4mDg1qUdM5LeUdvIyqwj3XHjFKAAvA==",
+    "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
+      "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.310.0.tgz",
+      "integrity": "sha512-yU/4QnHHuQ5z3vsUqMQVfYLbZGYwpYblPiuZx4Zo9+x0PBkNjYMqctdDcrpoH9Z2xZiDN16AmQGK1tix117ZKw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/client-iot-events/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.272.0.tgz",
-      "integrity": "sha512-ljK+R3l+Q1LIHrcR+Knhk0rmcSkfFadZ8V+crEGpABf/QUQRg7NkZMsoe814tfBO5F7tMxo8wwwSdaVNNHtoRA==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.310.0.tgz",
+      "integrity": "sha512-Ra3pEl+Gn2BpeE7KiDGpi4zj7WJXZA5GXnGo3mjbi9+Y3zrbuhJAbdZO3mO/o7xDgMC6ph4xCTbaSGzU6b6EDg==",
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1165,46 +1246,46 @@
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise": {
-      "version": "3.281.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-iotsitewise/-/client-iotsitewise-3.281.0.tgz",
-      "integrity": "sha512-1Mz5DBBiw4JNrtcmMvIWk+8V+YVfRBG81GuikF7FBuqdICuEuVoZODPcLSOjXvjW6uRwBPuauPqRwnUXCqocXQ==",
+      "version": "3.319.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-iotsitewise/-/client-iotsitewise-3.319.0.tgz",
+      "integrity": "sha512-DrMT1MpHgEPyfZrle7RNB6/uIdLTNPue22KIc9Mlpv1Ykd9BAUH02KG/74A1xCvPxduS66n0ceufJa5APfBtmA==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.281.0",
-        "@aws-sdk/config-resolver": "3.272.0",
-        "@aws-sdk/credential-provider-node": "3.281.0",
-        "@aws-sdk/fetch-http-handler": "3.272.0",
-        "@aws-sdk/hash-node": "3.272.0",
-        "@aws-sdk/invalid-dependency": "3.272.0",
-        "@aws-sdk/middleware-content-length": "3.272.0",
-        "@aws-sdk/middleware-endpoint": "3.272.0",
-        "@aws-sdk/middleware-host-header": "3.278.0",
-        "@aws-sdk/middleware-logger": "3.272.0",
-        "@aws-sdk/middleware-recursion-detection": "3.272.0",
-        "@aws-sdk/middleware-retry": "3.272.0",
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/middleware-signing": "3.272.0",
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/middleware-user-agent": "3.272.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/node-http-handler": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/smithy-client": "3.279.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-        "@aws-sdk/util-defaults-mode-node": "3.279.0",
-        "@aws-sdk/util-endpoints": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "@aws-sdk/util-user-agent-browser": "3.272.0",
-        "@aws-sdk/util-user-agent-node": "3.272.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "@aws-sdk/util-waiter": "3.272.0",
-        "tslib": "^2.3.1",
+        "@aws-sdk/client-sts": "3.319.0",
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/credential-provider-node": "3.319.0",
+        "@aws-sdk/fetch-http-handler": "3.310.0",
+        "@aws-sdk/hash-node": "3.310.0",
+        "@aws-sdk/invalid-dependency": "3.310.0",
+        "@aws-sdk/middleware-content-length": "3.310.0",
+        "@aws-sdk/middleware-endpoint": "3.310.0",
+        "@aws-sdk/middleware-host-header": "3.310.0",
+        "@aws-sdk/middleware-logger": "3.310.0",
+        "@aws-sdk/middleware-recursion-detection": "3.310.0",
+        "@aws-sdk/middleware-retry": "3.310.0",
+        "@aws-sdk/middleware-serde": "3.310.0",
+        "@aws-sdk/middleware-signing": "3.310.0",
+        "@aws-sdk/middleware-stack": "3.310.0",
+        "@aws-sdk/middleware-user-agent": "3.319.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/node-http-handler": "3.310.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/smithy-client": "3.316.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+        "@aws-sdk/util-defaults-mode-node": "3.316.0",
+        "@aws-sdk/util-endpoints": "3.319.0",
+        "@aws-sdk/util-retry": "3.310.0",
+        "@aws-sdk/util-user-agent-browser": "3.310.0",
+        "@aws-sdk/util-user-agent-node": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@aws-sdk/util-waiter": "3.310.0",
+        "tslib": "^2.5.0",
         "uuid": "^8.3.2"
       },
       "engines": {
@@ -1288,387 +1369,394 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/abort-controller": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.272.0.tgz",
-      "integrity": "sha512-s2TV3phapcTwZNr4qLxbfuQuE9ZMP4RoJdkvRRCkKdm6jslsWLJf2Zlcxti/23hOlINUMYv2iXE2pftIgWGdpg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.310.0.tgz",
+      "integrity": "sha512-v1zrRQxDLA1MdPim159Vx/CPHqsB4uybSxRi1CnfHO5ZjHryx3a5htW2gdGAykVCul40+yJXvfpufMrELVxH+g==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/client-sso": {
-      "version": "3.281.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.281.0.tgz",
-      "integrity": "sha512-3RvO5zClQhu37w9VMLoHPGk58S3y8Spb7XX8rW51bm5TUglYQskQ0X2VLEUW/7ZGx/peokHws9Z9+w5yGq5sdA==",
+      "version": "3.319.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.319.0.tgz",
+      "integrity": "sha512-g46KgAjRiYBS8Oi85DPwSAQpt+Hgmw/YFgGVwZqMfTL70KNJwLFKRa5D9UocQd7t7OjPRdKF7g0Gp5peyAK9dw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.272.0",
-        "@aws-sdk/fetch-http-handler": "3.272.0",
-        "@aws-sdk/hash-node": "3.272.0",
-        "@aws-sdk/invalid-dependency": "3.272.0",
-        "@aws-sdk/middleware-content-length": "3.272.0",
-        "@aws-sdk/middleware-endpoint": "3.272.0",
-        "@aws-sdk/middleware-host-header": "3.278.0",
-        "@aws-sdk/middleware-logger": "3.272.0",
-        "@aws-sdk/middleware-recursion-detection": "3.272.0",
-        "@aws-sdk/middleware-retry": "3.272.0",
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/middleware-user-agent": "3.272.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/node-http-handler": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/smithy-client": "3.279.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-        "@aws-sdk/util-defaults-mode-node": "3.279.0",
-        "@aws-sdk/util-endpoints": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "@aws-sdk/util-user-agent-browser": "3.272.0",
-        "@aws-sdk/util-user-agent-node": "3.272.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/fetch-http-handler": "3.310.0",
+        "@aws-sdk/hash-node": "3.310.0",
+        "@aws-sdk/invalid-dependency": "3.310.0",
+        "@aws-sdk/middleware-content-length": "3.310.0",
+        "@aws-sdk/middleware-endpoint": "3.310.0",
+        "@aws-sdk/middleware-host-header": "3.310.0",
+        "@aws-sdk/middleware-logger": "3.310.0",
+        "@aws-sdk/middleware-recursion-detection": "3.310.0",
+        "@aws-sdk/middleware-retry": "3.310.0",
+        "@aws-sdk/middleware-serde": "3.310.0",
+        "@aws-sdk/middleware-stack": "3.310.0",
+        "@aws-sdk/middleware-user-agent": "3.319.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/node-http-handler": "3.310.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/smithy-client": "3.316.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+        "@aws-sdk/util-defaults-mode-node": "3.316.0",
+        "@aws-sdk/util-endpoints": "3.319.0",
+        "@aws-sdk/util-retry": "3.310.0",
+        "@aws-sdk/util-user-agent-browser": "3.310.0",
+        "@aws-sdk/util-user-agent-node": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.281.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.281.0.tgz",
-      "integrity": "sha512-P6zf9pDuxApVoCYStAg7L8BU9AcWI8PxfLSX4r2WnmcQropxzPJ3op1j9nvbwwBDMFWephijVY4AVp8MqPcPyg==",
+      "version": "3.319.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.319.0.tgz",
+      "integrity": "sha512-GJBgT/tephRZY3oTbDBMv+G9taoqKUIvGPn+7shmzz2P1SerutsRSfKfDXV+VptPNRoGmjjCLPmWjMFYbFKILQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.272.0",
-        "@aws-sdk/fetch-http-handler": "3.272.0",
-        "@aws-sdk/hash-node": "3.272.0",
-        "@aws-sdk/invalid-dependency": "3.272.0",
-        "@aws-sdk/middleware-content-length": "3.272.0",
-        "@aws-sdk/middleware-endpoint": "3.272.0",
-        "@aws-sdk/middleware-host-header": "3.278.0",
-        "@aws-sdk/middleware-logger": "3.272.0",
-        "@aws-sdk/middleware-recursion-detection": "3.272.0",
-        "@aws-sdk/middleware-retry": "3.272.0",
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/middleware-user-agent": "3.272.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/node-http-handler": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/smithy-client": "3.279.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-        "@aws-sdk/util-defaults-mode-node": "3.279.0",
-        "@aws-sdk/util-endpoints": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "@aws-sdk/util-user-agent-browser": "3.272.0",
-        "@aws-sdk/util-user-agent-node": "3.272.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/fetch-http-handler": "3.310.0",
+        "@aws-sdk/hash-node": "3.310.0",
+        "@aws-sdk/invalid-dependency": "3.310.0",
+        "@aws-sdk/middleware-content-length": "3.310.0",
+        "@aws-sdk/middleware-endpoint": "3.310.0",
+        "@aws-sdk/middleware-host-header": "3.310.0",
+        "@aws-sdk/middleware-logger": "3.310.0",
+        "@aws-sdk/middleware-recursion-detection": "3.310.0",
+        "@aws-sdk/middleware-retry": "3.310.0",
+        "@aws-sdk/middleware-serde": "3.310.0",
+        "@aws-sdk/middleware-stack": "3.310.0",
+        "@aws-sdk/middleware-user-agent": "3.319.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/node-http-handler": "3.310.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/smithy-client": "3.316.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+        "@aws-sdk/util-defaults-mode-node": "3.316.0",
+        "@aws-sdk/util-endpoints": "3.319.0",
+        "@aws-sdk/util-retry": "3.310.0",
+        "@aws-sdk/util-user-agent-browser": "3.310.0",
+        "@aws-sdk/util-user-agent-node": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/client-sts": {
-      "version": "3.281.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.281.0.tgz",
-      "integrity": "sha512-w8QomyhCVEArRcXgOkjbofiS/PLEKWRAyYBovjMS1cGhns2ZYJXFgHNgr3VGE54TghUc5dR1CqKuBKKM4ThrgA==",
+      "version": "3.319.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.319.0.tgz",
+      "integrity": "sha512-PRGGKCSKtyM3x629J9j4DMsH1cQT8UGW+R67u9Q5HrMK05gfjpmg+X1DQ3pgve4D8MI4R/Cm3NkYl2eUTbQHQg==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.272.0",
-        "@aws-sdk/credential-provider-node": "3.281.0",
-        "@aws-sdk/fetch-http-handler": "3.272.0",
-        "@aws-sdk/hash-node": "3.272.0",
-        "@aws-sdk/invalid-dependency": "3.272.0",
-        "@aws-sdk/middleware-content-length": "3.272.0",
-        "@aws-sdk/middleware-endpoint": "3.272.0",
-        "@aws-sdk/middleware-host-header": "3.278.0",
-        "@aws-sdk/middleware-logger": "3.272.0",
-        "@aws-sdk/middleware-recursion-detection": "3.272.0",
-        "@aws-sdk/middleware-retry": "3.272.0",
-        "@aws-sdk/middleware-sdk-sts": "3.272.0",
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/middleware-signing": "3.272.0",
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/middleware-user-agent": "3.272.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/node-http-handler": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/smithy-client": "3.279.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-        "@aws-sdk/util-defaults-mode-node": "3.279.0",
-        "@aws-sdk/util-endpoints": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "@aws-sdk/util-user-agent-browser": "3.272.0",
-        "@aws-sdk/util-user-agent-node": "3.272.0",
-        "@aws-sdk/util-utf8": "3.254.0",
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/credential-provider-node": "3.319.0",
+        "@aws-sdk/fetch-http-handler": "3.310.0",
+        "@aws-sdk/hash-node": "3.310.0",
+        "@aws-sdk/invalid-dependency": "3.310.0",
+        "@aws-sdk/middleware-content-length": "3.310.0",
+        "@aws-sdk/middleware-endpoint": "3.310.0",
+        "@aws-sdk/middleware-host-header": "3.310.0",
+        "@aws-sdk/middleware-logger": "3.310.0",
+        "@aws-sdk/middleware-recursion-detection": "3.310.0",
+        "@aws-sdk/middleware-retry": "3.310.0",
+        "@aws-sdk/middleware-sdk-sts": "3.310.0",
+        "@aws-sdk/middleware-serde": "3.310.0",
+        "@aws-sdk/middleware-signing": "3.310.0",
+        "@aws-sdk/middleware-stack": "3.310.0",
+        "@aws-sdk/middleware-user-agent": "3.319.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/node-http-handler": "3.310.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/smithy-client": "3.316.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+        "@aws-sdk/util-defaults-mode-node": "3.316.0",
+        "@aws-sdk/util-endpoints": "3.319.0",
+        "@aws-sdk/util-retry": "3.310.0",
+        "@aws-sdk/util-user-agent-browser": "3.310.0",
+        "@aws-sdk/util-user-agent-node": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
         "fast-xml-parser": "4.1.2",
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/config-resolver": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.272.0.tgz",
-      "integrity": "sha512-Dr4CffRVNsOp3LRNdpvcH6XuSgXOSLblWliCy/5I86cNl567KVMxujVx6uPrdTXYs2h1rt3MNl6jQGnAiJeTbw==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.310.0.tgz",
+      "integrity": "sha512-8vsT+/50lOqfDxka9m/rRt6oxv1WuGZoP8oPMk0Dt+TxXMbAzf4+rejBgiB96wshI1k3gLokYRjSQZn+dDtT8g==",
       "dependencies": {
-        "@aws-sdk/signature-v4": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-config-provider": "3.310.0",
+        "@aws-sdk/util-middleware": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.272.0.tgz",
-      "integrity": "sha512-QI65NbLnKLYHyTYhXaaUrq6eVsCCrMUb05WDA7+TJkWkjXesovpjc8vUKgFiLSxmgKmb2uOhHNcDyObKMrYQFw==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.310.0.tgz",
+      "integrity": "sha512-vvIPQpI16fj95xwS7M3D48F7QhZJBnnCgB5lR+b7So+vsG9ibm1mZRVGzVpdxCvgyOhHFbvrby9aalNJmmIP1A==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.272.0.tgz",
-      "integrity": "sha512-wwAfVY1jTFQEfxVfdYD5r5ieYGl+0g4nhekVxNMqE8E1JeRDd18OqiwAflzpgBIqxfqvCUkf+vl5JYyacMkNAQ==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.310.0.tgz",
+      "integrity": "sha512-baxK7Zp6dai5AGW01FIW27xS2KAaPUmKLIXv5SvFYsUgXXvNW55im4uG3b+2gA0F7V+hXvVBH08OEqmwW6we5w==",
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.281.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.281.0.tgz",
-      "integrity": "sha512-H99nhMhHImQKgNhHKYc6usTS6UK8KzCcVGpILLVTuP97YlrYAMFAVstA3Xk6mZ28JAbHVXvI6vJjkMNOzCSKCA==",
+      "version": "3.319.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.319.0.tgz",
+      "integrity": "sha512-pzx388Fw1KlSgmIMUyRY8DJVYM3aXpwzjprD4RiQVPJeAI+t7oQmEvd2FiUZEuHDjWXcuonxgU+dk7i7HUk/HQ==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.272.0",
-        "@aws-sdk/credential-provider-imds": "3.272.0",
-        "@aws-sdk/credential-provider-process": "3.272.0",
-        "@aws-sdk/credential-provider-sso": "3.281.0",
-        "@aws-sdk/credential-provider-web-identity": "3.272.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/credential-provider-env": "3.310.0",
+        "@aws-sdk/credential-provider-imds": "3.310.0",
+        "@aws-sdk/credential-provider-process": "3.310.0",
+        "@aws-sdk/credential-provider-sso": "3.319.0",
+        "@aws-sdk/credential-provider-web-identity": "3.310.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.281.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.281.0.tgz",
-      "integrity": "sha512-jhddd+lJp8G8hBJ+6glmXjfWJT3nxiE1aliH3fBC4RR3D+1kRXc99Xg6mbUb8bm+GrVZ4gzfiqSgg+ByKjd7xA==",
+      "version": "3.319.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.319.0.tgz",
+      "integrity": "sha512-DS4a0Rdd7ZtMshoeE+zuSgbC05YBcdzd0h89u/eX+1Yqx+HCjeb8WXkbXsz0Mwx8q9TE04aS8f6Bw9J4x4mO5g==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.272.0",
-        "@aws-sdk/credential-provider-imds": "3.272.0",
-        "@aws-sdk/credential-provider-ini": "3.281.0",
-        "@aws-sdk/credential-provider-process": "3.272.0",
-        "@aws-sdk/credential-provider-sso": "3.281.0",
-        "@aws-sdk/credential-provider-web-identity": "3.272.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/credential-provider-env": "3.310.0",
+        "@aws-sdk/credential-provider-imds": "3.310.0",
+        "@aws-sdk/credential-provider-ini": "3.319.0",
+        "@aws-sdk/credential-provider-process": "3.310.0",
+        "@aws-sdk/credential-provider-sso": "3.319.0",
+        "@aws-sdk/credential-provider-web-identity": "3.310.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.272.0.tgz",
-      "integrity": "sha512-hiCAjWWm2PeBFp5cjkxqyam/XADjiS+e7GzwC34TbZn3LisS0uoweLojj9tD11NnnUhyhbLteUvu5+rotOLwrg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.310.0.tgz",
+      "integrity": "sha512-h73sg6GPMUWC+3zMCbA1nZ2O03nNJt7G96JdmnantiXBwHpRKWW8nBTLzx5uhXn6hTuTaoQRP/P+oxQJKYdMmA==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.281.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.281.0.tgz",
-      "integrity": "sha512-IqJnpXuLpJYoSCf/Rt66/CPVTjfkam3z9+ZvlQJV+VbK+vGj276qEtTmSN3XPZZgF1XbWptvkzIWDszLhHiZmg==",
+      "version": "3.319.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.319.0.tgz",
+      "integrity": "sha512-gAUnWH41lxkIbANXu+Rz5zS0Iavjjmpf3C56vAMT7oaYZ3Cg/Ys5l2SwAucQGOCA2DdS2hDiSI8E+Yhr4F5toA==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.281.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/token-providers": "3.281.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/client-sso": "3.319.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/token-providers": "3.319.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.272.0.tgz",
-      "integrity": "sha512-ImrHMkcgneGa/HadHAQXPwOrX26sAKuB8qlMxZF/ZCM2B55u8deY+ZVkVuraeKb7YsahMGehPFOfRAF6mvFI5Q==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.310.0.tgz",
+      "integrity": "sha512-H4SzuZXILNhK6/IR1uVvsUDZvzc051hem7GLyYghBCu8mU+tq28YhKE8MfSroi6eL2e5Vujloij1OM2EQQkPkw==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.272.0.tgz",
-      "integrity": "sha512-1Qhm9e0RbS1Xf4CZqUbQyUMkDLd7GrsRXWIvm9b86/vgeV8/WnjO3CMue9D51nYgcyQORhYXv6uVjAYCWbUExA==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.310.0.tgz",
+      "integrity": "sha512-Bi9vIwzdkw1zMcvi/zGzlWS9KfIEnAq4NNhsnCxbQ4OoIRU9wvU+WGZdBBhxg0ZxZmpp1j1aZhU53lLjA07MHw==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/querystring-builder": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/querystring-builder": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/hash-node": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.272.0.tgz",
-      "integrity": "sha512-40dwND+iAm3VtPHPZu7/+CIdVJFk2s0cWZt1lOiMPMSXycSYJ45wMk7Lly3uoqRx0uWfFK5iT2OCv+fJi5jTng==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.310.0.tgz",
+      "integrity": "sha512-NvE2fhRc8GRwCXBfDehxVAWCmVwVMILliAKVPAEr4yz2CkYs0tqU51S48x23dtna07H4qHtgpeNqVTthcIQOEQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.272.0.tgz",
-      "integrity": "sha512-ysW6wbjl1Y78txHUQ/Tldj2Rg1BI7rpMO9B9xAF6yAX3mQ7t6SUPQG/ewOGvH2208NBIl3qP5e/hDf0Q6r/1iw==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.310.0.tgz",
+      "integrity": "sha512-1s5RG5rSPXoa/aZ/Kqr5U/7lqpx+Ry81GprQ2bxWqJvWQIJ0IRUwo5pk8XFxbKVr/2a+4lZT/c3OGoBOM1yRRA==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
+      "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.272.0.tgz",
-      "integrity": "sha512-sAbDZSTNmLX+UTGwlUHJBWy0QGQkiClpHwVFXACon+aG0ySLNeRKEVYs6NCPYldw4cj6hveLUn50cX44ukHErw==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.310.0.tgz",
+      "integrity": "sha512-P8tQZxgDt6CAh1wd/W6WPzjc+uWPJwQkm+F7rAwRlM+k9q17HrhnksGDKcpuuLyIhPQYdmOMIkpKVgXGa4avhQ==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/middleware-endpoint": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.272.0.tgz",
-      "integrity": "sha512-Dk3JVjj7SxxoUKv3xGiOeBksvPtFhTDrVW75XJ98Ymv8gJH5L1sq4hIeJAHRKogGiRFq2J73mnZSlM9FVXEylg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.310.0.tgz",
+      "integrity": "sha512-Z+N2vOL8K354/lstkClxLLsr6hCpVRh+0tCMXrVj66/NtKysCEZ/0b9LmqOwD9pWHNiI2mJqXwY0gxNlKAroUg==",
       "dependencies": {
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/signature-v4": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/middleware-serde": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-middleware": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.278.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.278.0.tgz",
-      "integrity": "sha512-oTkF3exy89KE8NgSeXFwD+0H0GRKL2qUw92t3caEj7+4KzU/0m3t7NtKlq2NLRtTJhZ/izYRpV536oogLzGm3g==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.310.0.tgz",
+      "integrity": "sha512-QWSA+46/hXorXyWa61ic2K7qZzwHTiwfk2e9mRRjeIRepUgI3qxFjsYqrWtrOGBjmFmq0pYIY8Bb/DCJuQqcoA==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.272.0.tgz",
-      "integrity": "sha512-u2SQ0hWrFwxbxxYMG5uMEgf01pQY5jauK/LYWgGIvuCmFgiyRQQP3oN7kkmsxnS9MWmNmhbyQguX2NY02s5e9w==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.310.0.tgz",
+      "integrity": "sha512-Lurm8XofrASBRnAVtiSNuDSRsRqPNg27RIFLLsLp/pqog9nFJ0vz0kgdb9S5Z+zw83Mm+UlqOe6D8NTUNp4fVg==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.272.0.tgz",
-      "integrity": "sha512-Gp/eKWeUWVNiiBdmUM2qLkBv+VLSJKoWAO+aKmyxxwjjmWhE0FrfA1NQ1a3g+NGMhRbAfQdaYswRAKsul70ISg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.310.0.tgz",
+      "integrity": "sha512-SuB75/xk/gyue24gkriTwO2jFd7YcUGZDClQYuRejgbXSa3CO0lWyawQtfLcSSEBp9izrEVXuFH24K1eAft5nQ==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.272.0.tgz",
-      "integrity": "sha512-pCGvHM7C76VbO/dFerH+Vwf7tGv7j+e+eGrvhQ35mRghCtfIou/WMfTZlD1TNee93crrAQQVZKjtW3dMB3WCzg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.310.0.tgz",
+      "integrity": "sha512-oTPsRy2W4s+dfxbJPW7Km+hHtv/OMsNsVfThAq8DDYKC13qlr1aAyOqGLD+dpBy2aKe7ss517Sy2HcHtHqm7/g==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/service-error-classification": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-middleware": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "tslib": "^2.3.1",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/service-error-classification": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-middleware": "3.310.0",
+        "@aws-sdk/util-retry": "3.310.0",
+        "tslib": "^2.5.0",
         "uuid": "^8.3.2"
       },
       "engines": {
@@ -1676,320 +1764,394 @@
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.272.0.tgz",
-      "integrity": "sha512-VvYPg7LrDIjUOWueSzo2wBzcNG7dw+cmzV6zAKaLxf0RC5jeAP4hE0OzDiiZfDrjNghEzgq/V+0NO+LewqYL9Q==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.310.0.tgz",
+      "integrity": "sha512-+5PFwlYNLvLLIfw0ASAoWV/iIF8Zv6R6QGtyP0CclhRSvNjgbQDVnV0g95MC5qvh+GB/Yjlkt8qAjLSPjHfsrQ==",
       "dependencies": {
-        "@aws-sdk/middleware-signing": "3.272.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/signature-v4": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/middleware-signing": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.272.0.tgz",
-      "integrity": "sha512-kW1uOxgPSwtXPB5rm3QLdWomu42lkYpQL94tM1BjyFOWmBLO2lQhk5a7Dw6HkTozT9a+vxtscLChRa6KZe61Hw==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.310.0.tgz",
+      "integrity": "sha512-RNeeTVWSLTaentUeCgQKZhAl+C6hxtwD78cQWS10UymWpQFwbaxztzKUu4UQS5xA2j6PxwPRRUjqa4jcFjfLsg==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.272.0.tgz",
-      "integrity": "sha512-4LChFK4VAR91X+dupqM8fQqYhFGE0G4Bf9rQlVTgGSbi2KUOmpqXzH0/WKE228nKuEhmH8+Qd2VPSAE2JcyAUA==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.310.0.tgz",
+      "integrity": "sha512-f9mKq+XMdW207Af3hKjdTnpNhdtwqWuvFs/ZyXoOkp/g1MY1O6L23Jy6i52m29LxbT4AuNRG1oKODfXM0vYVjQ==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/signature-v4": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-middleware": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/signature-v4": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-middleware": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.272.0.tgz",
-      "integrity": "sha512-jhwhknnPBGhfXAGV5GXUWfEhDFoP/DN8MPCO2yC5OAxyp6oVJ8lTPLkZYMTW5VL0c0eG44dXpF4Ib01V+PlDrQ==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.310.0.tgz",
+      "integrity": "sha512-010O1PD+UAcZVKRvqEusE1KJqN96wwrf6QsqbRM0ywsKQ21NDweaHvEDlds2VHpgmofxkRLRu/IDrlPkKRQrRg==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.272.0.tgz",
-      "integrity": "sha512-Qy7/0fsDJxY5l0bEk7WKDfqb4Os/sCAgFR2zEvrhDtbkhYPf72ysvg/nRUTncmCbo8tOok4SJii2myk8KMfjjw==",
+      "version": "3.319.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.319.0.tgz",
+      "integrity": "sha512-ytaLx2dlR5AdMSne6FuDCISVg8hjyKj+cHU20b2CRA/E/z+XXrLrssp4JrCgizRKPPUep0psMIa22Zd6osTT5Q==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-endpoints": "3.319.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.272.0.tgz",
-      "integrity": "sha512-YYCIBh9g1EQo7hm2l22HX5Yr9RoPQ2RCvhzKvF1n1e8t1QH4iObQrYUtqHG4khcm64Cft8C5MwZmgzHbya5Z6Q==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.310.0.tgz",
+      "integrity": "sha512-T/Pp6htc6hq/Cq+MLNDSyiwWCMVF6GqbBbXKVlO5L8rdHx4sq9xPdoPveZhGWrxvkanjA6eCwUp6E0riBOSVng==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.272.0.tgz",
-      "integrity": "sha512-VrW9PjhhngeyYp4yGYPe5S0vgZH6NwU3Po9xAgayUeE37Inr7LS1YteFMHdpgsUUeNXnh7d06CXqHo1XjtqOKA==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.310.0.tgz",
+      "integrity": "sha512-irv9mbcM9xC2xYjArQF5SYmHBMu4ciMWtGsoHII1nRuFOl9FoT4ffTvEPuLlfC6pznzvKt9zvnm6xXj7gDChKg==",
       "dependencies": {
-        "@aws-sdk/abort-controller": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/querystring-builder": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/abort-controller": "3.310.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/querystring-builder": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/property-provider": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.272.0.tgz",
-      "integrity": "sha512-V1pZTaH5eqpAt8O8CzbItHhOtzIfFuWymvwZFkAtwKuaHpnl7jjrTouV482zoq8AD/fF+VVSshwBKYA7bhidIw==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.310.0.tgz",
+      "integrity": "sha512-3lxDb0akV6BBzmFe4nLPaoliQbAifyWJhuvuDOu7e8NzouvpQXs0275w9LePhhcgjKAEVXUIse05ZW2DLbxo/g==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.272.0.tgz",
-      "integrity": "sha512-4JQ54v5Yn08jspNDeHo45CaSn1CvTJqS1Ywgr79eU6jBExtguOWv6LNtwVSBD9X37v88iqaxt8iu1Z3pZZAJeg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.310.0.tgz",
+      "integrity": "sha512-fgZ1aw/irQtnrsR58pS8ThKOWo57Py3xX6giRvwSgZDEcxHfVzuQjy9yPuV++v04fdmdtgpbGf8WfvAAJ11yXQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.272.0.tgz",
-      "integrity": "sha512-ndo++7GkdCj5tBXE6rGcITpSpZS4PfyV38wntGYAlj9liL1omk3bLZRY6uzqqkJpVHqbg2fD7O2qHNItzZgqhw==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.310.0.tgz",
+      "integrity": "sha512-ZHH8GV/80+pWGo7DzsvwvXR5xVxUHXUvPJPFAkhr6nCf78igdoF8gR10ScFoEKbtEapoNTaZlKHPXxpD8aPG7A==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.272.0.tgz",
-      "integrity": "sha512-5oS4/9n6N1LZW9tI3qq/0GnCuWoOXRgcHVB+AJLRBvDbEe+GI+C/xK1tKLsfpDNgsQJHc4IPQoIt4megyZ/1+A==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.310.0.tgz",
+      "integrity": "sha512-YkIznoP6lsiIUHinx++/lbb3tlMURGGqMpo0Pnn32zYzGrJXA6eC3D0as2EcMjo55onTfuLcIiX4qzXes2MYOA==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.272.0.tgz",
-      "integrity": "sha512-REoltM1LK9byyIufLqx9znhSolPcHQgVHIA2S0zu5sdt5qER4OubkLAXuo4MBbisUTmh8VOOvIyUb5ijZCXq1w==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.310.0.tgz",
+      "integrity": "sha512-PuyC7k3qfIKeH2LCnDwbttMOKq3qAx4buvg0yfnJtQOz6t1AR8gsnAq0CjKXXyfkXwNKWTqCpE6lVNUIkXgsMw==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.272.0.tgz",
-      "integrity": "sha512-lzFPohp5sy2XvwFjZIzLVCRpC0i5cwBiaXmFzXYQZJm6FSCszHO4ax+m9yrtlyVFF/2YPWl+/bzNthy4aJtseA==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.310.0.tgz",
+      "integrity": "sha512-N0q9pG0xSjQwc690YQND5bofm+4nfUviQ/Ppgan2kU6aU0WUq8KwgHJBto/YEEI+VlrME30jZJnxtOvcZJc2XA==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/signature-v4": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.272.0.tgz",
-      "integrity": "sha512-pWxnHG1NqJWMwlhJ6NHNiUikOL00DHROmxah6krJPMPq4I3am2KY2Rs/8ouWhnEXKaHAv4EQhSALJ+7Mq5S4/A==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.310.0.tgz",
+      "integrity": "sha512-1M60P1ZBNAjCFv9sYW29OF6okktaeibWyW3lMXqzoHF70lHBZh+838iUchznXUA5FLabfn4jBFWMRxlAXJUY2Q==",
       "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-middleware": "3.272.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "@aws-sdk/util-middleware": "3.310.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/smithy-client": {
-      "version": "3.279.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.279.0.tgz",
-      "integrity": "sha512-ZcYWUQDGAYN6NXRpJuSn46PetrpPCA6TrDVwP9+3pERzTXZ66npXoG2XhHjNrOXy/Ted5A3OxKrM4/zLu9tK3A==",
+      "version": "3.316.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.316.0.tgz",
+      "integrity": "sha512-6YXOKbRnXeS8r8RWzuL6JMBolDYM5Wa4fD/VY6x/wK78i2xErHOvqzHgyyeLI1MMw4uqyd4wRNJNWC9TMPduXw==",
       "dependencies": {
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/middleware-stack": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/token-providers": {
-      "version": "3.281.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.281.0.tgz",
-      "integrity": "sha512-36Vg/F6Edm7qdjcTeNVON+sK2edgHhmhTtAEjWcuUk5AX/Et+Ate/A2N8HD3nxwlAcgidfnBC9SHYJatbhcEnQ==",
+      "version": "3.319.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.319.0.tgz",
+      "integrity": "sha512-5utg6VL6Pl0uiLUn8ZJPYYxzCb9VRPsgJmGXktRUwq0YlTJ6ABcaxTXwZcC++sjh/qyCQDK5PPLNU5kIBttHMQ==",
       "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.281.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/client-sso-oidc": "3.319.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/types": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.272.0.tgz",
-      "integrity": "sha512-MmmL6vxMGP5Bsi+4wRx4mxYlU/LX6M0noOXrDh/x5FfG7/4ZOar/nDxqDadhJtNM88cuWVHZWY59P54JzkGWmA==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.310.0.tgz",
+      "integrity": "sha512-j8eamQJ7YcIhw7fneUfs8LYl3t01k4uHi4ZDmNRgtbmbmTTG3FZc2MotStZnp3nZB6vLiPF1o5aoJxWVvkzS6A==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/url-parser": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.272.0.tgz",
-      "integrity": "sha512-vX/Tx02PlnQ/Kgtf5TnrNDHPNbY+amLZjW0Z1d9vzAvSZhQ4i9Y18yxoRDIaDTCNVRDjdhV8iuctW+05PB5JtQ==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.310.0.tgz",
+      "integrity": "sha512-mCLnCaSB9rQvAgx33u0DujLvr4d5yEm/W5r789GblwwQnlNXedVu50QRizMLTpltYWyAUoXjJgQnJHmJMaKXhw==",
       "dependencies": {
-        "@aws-sdk/querystring-parser": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/querystring-parser": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/util-base64": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
+      "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
+      "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
+      "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
+      "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
+      "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.279.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.279.0.tgz",
-      "integrity": "sha512-RnchYRrpapTT5Hu23LOfk6e8RMVq0kUzho6xA6TJj1a4uGxkcRMvgzPipCq1P5uHu0mrkQBg9pGPEVNOUs38/Q==",
+      "version": "3.316.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.316.0.tgz",
+      "integrity": "sha512-6FSqLhYmaihtH2n1s4b2rlLW0ABU8N6VZIfzLfe2ING4PF0MzfaMMhnTFUHVXfKCVGoR8yP6iyFTRCyHGVEL1w==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">= 10.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.279.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.279.0.tgz",
-      "integrity": "sha512-A2NB10xReWC+GSnOivKGZ9rnljIZdEP8WMCQQEnA6DJNI19AUFF/O9QJ9y+cHGLKEms7jH86Y99wShdpzAK+Jw==",
+      "version": "3.316.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.316.0.tgz",
+      "integrity": "sha512-dkYy10hdjPSScXXvnjGpZpnJxllkb6ICHgLMwZ4JczLHhPM12T/4PQ758YN8HS+muiYDGX1Bl2z1jd/bMcewBQ==",
       "dependencies": {
-        "@aws-sdk/config-resolver": "3.272.0",
-        "@aws-sdk/credential-provider-imds": "3.272.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/credential-provider-imds": "3.310.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">= 10.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.272.0.tgz",
-      "integrity": "sha512-c4MPUaJt2G6gGpoiwIOqDfUa98c1J63RpYvf/spQEKOtC/tF5Gfqlxuq8FnAl5lHnrqj1B9ZXLLxFhHtDR0IiQ==",
+      "version": "3.319.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.319.0.tgz",
+      "integrity": "sha512-3I64UMoYA2e2++oOUJXRcFtYLpLylnZFRltWfPo1B3dLlf+MIWat9djT+mMus+hW1ntLsvAIVu1hLVePJC0gvw==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
+      "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/util-middleware": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.272.0.tgz",
-      "integrity": "sha512-Abw8m30arbwxqmeMMha5J11ESpHUNmCeSqSzE8/C4B8jZQtHY4kq7f+upzcNIQ11lsd+uzBEzNG3+dDRi0XOJQ==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.310.0.tgz",
+      "integrity": "sha512-FTSUKL/eRb9X6uEZClrTe27QFXUNNp7fxYrPndZwk1hlaOP5ix+MIHBcI7pIiiY/JPfOUmPyZOu+HetlFXjWog==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/util-retry": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.272.0.tgz",
-      "integrity": "sha512-Ngha5414LR4gRHURVKC9ZYXsEJhMkm+SJ+44wlzOhavglfdcKKPUsibz5cKY1jpUV7oKECwaxHWpBB8r6h+hOg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.310.0.tgz",
+      "integrity": "sha512-FwWGhCBLfoivTMUHu1LIn4NjrN9JLJ/aX5aZmbcPIOhZVFJj638j0qDgZXyfvVqBuBZh7M8kGq0Oahy3dp69OA==",
       "dependencies": {
-        "@aws-sdk/service-error-classification": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/service-error-classification": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.272.0.tgz",
-      "integrity": "sha512-Lp5QX5bH6uuwBlIdr7w7OAcAI50ttyskb++yUr9i+SPvj6RI2dsfIBaK4mDg1qUdM5LeUdvIyqwj3XHjFKAAvA==",
+    "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
+      "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.310.0.tgz",
+      "integrity": "sha512-yU/4QnHHuQ5z3vsUqMQVfYLbZGYwpYblPiuZx4Zo9+x0PBkNjYMqctdDcrpoH9Z2xZiDN16AmQGK1tix117ZKw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/client-iotsitewise/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.272.0.tgz",
-      "integrity": "sha512-ljK+R3l+Q1LIHrcR+Knhk0rmcSkfFadZ8V+crEGpABf/QUQRg7NkZMsoe814tfBO5F7tMxo8wwwSdaVNNHtoRA==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.310.0.tgz",
+      "integrity": "sha512-Ra3pEl+Gn2BpeE7KiDGpi4zj7WJXZA5GXnGo3mjbi9+Y3zrbuhJAbdZO3mO/o7xDgMC6ph4xCTbaSGzU6b6EDg==",
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -2110,47 +2272,47 @@
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media": {
-      "version": "3.281.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kinesis-video-archived-media/-/client-kinesis-video-archived-media-3.281.0.tgz",
-      "integrity": "sha512-3jUDDhq1vglYXb41uTxFOgysAsKEc0rpI2craXpXyEvpiRm7NGBKWHxgCOZMsX9ivbWESQAXNL82gNMpkiduFg==",
+      "version": "3.321.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kinesis-video-archived-media/-/client-kinesis-video-archived-media-3.321.1.tgz",
+      "integrity": "sha512-HBHEvwYDGi4tH/Ya2mD2ztZVRLsq4qWQFYmS4ONWFuupt2oOxbyaVVvqoO9hC5Yv+HF38YvM6pRKwBMmJvMqhw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.281.0",
-        "@aws-sdk/config-resolver": "3.272.0",
-        "@aws-sdk/credential-provider-node": "3.281.0",
-        "@aws-sdk/fetch-http-handler": "3.272.0",
-        "@aws-sdk/hash-node": "3.272.0",
-        "@aws-sdk/invalid-dependency": "3.272.0",
-        "@aws-sdk/middleware-content-length": "3.272.0",
-        "@aws-sdk/middleware-endpoint": "3.272.0",
-        "@aws-sdk/middleware-host-header": "3.278.0",
-        "@aws-sdk/middleware-logger": "3.272.0",
-        "@aws-sdk/middleware-recursion-detection": "3.272.0",
-        "@aws-sdk/middleware-retry": "3.272.0",
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/middleware-signing": "3.272.0",
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/middleware-user-agent": "3.272.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/node-http-handler": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/smithy-client": "3.279.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-        "@aws-sdk/util-defaults-mode-node": "3.279.0",
-        "@aws-sdk/util-endpoints": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "@aws-sdk/util-stream-browser": "3.272.0",
-        "@aws-sdk/util-stream-node": "3.272.0",
-        "@aws-sdk/util-user-agent-browser": "3.272.0",
-        "@aws-sdk/util-user-agent-node": "3.272.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/client-sts": "3.321.1",
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/credential-provider-node": "3.321.1",
+        "@aws-sdk/fetch-http-handler": "3.310.0",
+        "@aws-sdk/hash-node": "3.310.0",
+        "@aws-sdk/invalid-dependency": "3.310.0",
+        "@aws-sdk/middleware-content-length": "3.310.0",
+        "@aws-sdk/middleware-endpoint": "3.310.0",
+        "@aws-sdk/middleware-host-header": "3.310.0",
+        "@aws-sdk/middleware-logger": "3.310.0",
+        "@aws-sdk/middleware-recursion-detection": "3.310.0",
+        "@aws-sdk/middleware-retry": "3.310.0",
+        "@aws-sdk/middleware-serde": "3.310.0",
+        "@aws-sdk/middleware-signing": "3.310.0",
+        "@aws-sdk/middleware-stack": "3.310.0",
+        "@aws-sdk/middleware-user-agent": "3.319.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/node-http-handler": "3.321.1",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/smithy-client": "3.316.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+        "@aws-sdk/util-defaults-mode-node": "3.316.0",
+        "@aws-sdk/util-endpoints": "3.319.0",
+        "@aws-sdk/util-retry": "3.310.0",
+        "@aws-sdk/util-stream-browser": "3.310.0",
+        "@aws-sdk/util-stream-node": "3.321.1",
+        "@aws-sdk/util-user-agent-browser": "3.310.0",
+        "@aws-sdk/util-user-agent-node": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -2233,387 +2395,394 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/abort-controller": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.272.0.tgz",
-      "integrity": "sha512-s2TV3phapcTwZNr4qLxbfuQuE9ZMP4RoJdkvRRCkKdm6jslsWLJf2Zlcxti/23hOlINUMYv2iXE2pftIgWGdpg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.310.0.tgz",
+      "integrity": "sha512-v1zrRQxDLA1MdPim159Vx/CPHqsB4uybSxRi1CnfHO5ZjHryx3a5htW2gdGAykVCul40+yJXvfpufMrELVxH+g==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/client-sso": {
-      "version": "3.281.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.281.0.tgz",
-      "integrity": "sha512-3RvO5zClQhu37w9VMLoHPGk58S3y8Spb7XX8rW51bm5TUglYQskQ0X2VLEUW/7ZGx/peokHws9Z9+w5yGq5sdA==",
+      "version": "3.321.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.321.1.tgz",
+      "integrity": "sha512-ecoT4tBGtRJR5G7oLBTMXZmgZZlff1amhSdKPEtkWxv6kWc8VPb5rRuRgVPsDR9HuesI6ZVlODptvGtnfkIJwA==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.272.0",
-        "@aws-sdk/fetch-http-handler": "3.272.0",
-        "@aws-sdk/hash-node": "3.272.0",
-        "@aws-sdk/invalid-dependency": "3.272.0",
-        "@aws-sdk/middleware-content-length": "3.272.0",
-        "@aws-sdk/middleware-endpoint": "3.272.0",
-        "@aws-sdk/middleware-host-header": "3.278.0",
-        "@aws-sdk/middleware-logger": "3.272.0",
-        "@aws-sdk/middleware-recursion-detection": "3.272.0",
-        "@aws-sdk/middleware-retry": "3.272.0",
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/middleware-user-agent": "3.272.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/node-http-handler": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/smithy-client": "3.279.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-        "@aws-sdk/util-defaults-mode-node": "3.279.0",
-        "@aws-sdk/util-endpoints": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "@aws-sdk/util-user-agent-browser": "3.272.0",
-        "@aws-sdk/util-user-agent-node": "3.272.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/fetch-http-handler": "3.310.0",
+        "@aws-sdk/hash-node": "3.310.0",
+        "@aws-sdk/invalid-dependency": "3.310.0",
+        "@aws-sdk/middleware-content-length": "3.310.0",
+        "@aws-sdk/middleware-endpoint": "3.310.0",
+        "@aws-sdk/middleware-host-header": "3.310.0",
+        "@aws-sdk/middleware-logger": "3.310.0",
+        "@aws-sdk/middleware-recursion-detection": "3.310.0",
+        "@aws-sdk/middleware-retry": "3.310.0",
+        "@aws-sdk/middleware-serde": "3.310.0",
+        "@aws-sdk/middleware-stack": "3.310.0",
+        "@aws-sdk/middleware-user-agent": "3.319.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/node-http-handler": "3.321.1",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/smithy-client": "3.316.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+        "@aws-sdk/util-defaults-mode-node": "3.316.0",
+        "@aws-sdk/util-endpoints": "3.319.0",
+        "@aws-sdk/util-retry": "3.310.0",
+        "@aws-sdk/util-user-agent-browser": "3.310.0",
+        "@aws-sdk/util-user-agent-node": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.281.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.281.0.tgz",
-      "integrity": "sha512-P6zf9pDuxApVoCYStAg7L8BU9AcWI8PxfLSX4r2WnmcQropxzPJ3op1j9nvbwwBDMFWephijVY4AVp8MqPcPyg==",
+      "version": "3.321.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.321.1.tgz",
+      "integrity": "sha512-PBVfHQbyrsfzbnO6u9d9Sik8JlXGLhHj3zLd87iBkYXBdHwD5NuvwWu7OtjUtrHjP4SfzodVwfjmTbDAFqbtzw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.272.0",
-        "@aws-sdk/fetch-http-handler": "3.272.0",
-        "@aws-sdk/hash-node": "3.272.0",
-        "@aws-sdk/invalid-dependency": "3.272.0",
-        "@aws-sdk/middleware-content-length": "3.272.0",
-        "@aws-sdk/middleware-endpoint": "3.272.0",
-        "@aws-sdk/middleware-host-header": "3.278.0",
-        "@aws-sdk/middleware-logger": "3.272.0",
-        "@aws-sdk/middleware-recursion-detection": "3.272.0",
-        "@aws-sdk/middleware-retry": "3.272.0",
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/middleware-user-agent": "3.272.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/node-http-handler": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/smithy-client": "3.279.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-        "@aws-sdk/util-defaults-mode-node": "3.279.0",
-        "@aws-sdk/util-endpoints": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "@aws-sdk/util-user-agent-browser": "3.272.0",
-        "@aws-sdk/util-user-agent-node": "3.272.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/fetch-http-handler": "3.310.0",
+        "@aws-sdk/hash-node": "3.310.0",
+        "@aws-sdk/invalid-dependency": "3.310.0",
+        "@aws-sdk/middleware-content-length": "3.310.0",
+        "@aws-sdk/middleware-endpoint": "3.310.0",
+        "@aws-sdk/middleware-host-header": "3.310.0",
+        "@aws-sdk/middleware-logger": "3.310.0",
+        "@aws-sdk/middleware-recursion-detection": "3.310.0",
+        "@aws-sdk/middleware-retry": "3.310.0",
+        "@aws-sdk/middleware-serde": "3.310.0",
+        "@aws-sdk/middleware-stack": "3.310.0",
+        "@aws-sdk/middleware-user-agent": "3.319.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/node-http-handler": "3.321.1",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/smithy-client": "3.316.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+        "@aws-sdk/util-defaults-mode-node": "3.316.0",
+        "@aws-sdk/util-endpoints": "3.319.0",
+        "@aws-sdk/util-retry": "3.310.0",
+        "@aws-sdk/util-user-agent-browser": "3.310.0",
+        "@aws-sdk/util-user-agent-node": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/client-sts": {
-      "version": "3.281.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.281.0.tgz",
-      "integrity": "sha512-w8QomyhCVEArRcXgOkjbofiS/PLEKWRAyYBovjMS1cGhns2ZYJXFgHNgr3VGE54TghUc5dR1CqKuBKKM4ThrgA==",
+      "version": "3.321.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.321.1.tgz",
+      "integrity": "sha512-AB+N4a1TVEKl9Sd5O2TxTprEZp7Va6zPZLMraFAYMdmJVBmCmmwyBs7ygju685DpQ1dos5PRsKCRcossyY5pDQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.272.0",
-        "@aws-sdk/credential-provider-node": "3.281.0",
-        "@aws-sdk/fetch-http-handler": "3.272.0",
-        "@aws-sdk/hash-node": "3.272.0",
-        "@aws-sdk/invalid-dependency": "3.272.0",
-        "@aws-sdk/middleware-content-length": "3.272.0",
-        "@aws-sdk/middleware-endpoint": "3.272.0",
-        "@aws-sdk/middleware-host-header": "3.278.0",
-        "@aws-sdk/middleware-logger": "3.272.0",
-        "@aws-sdk/middleware-recursion-detection": "3.272.0",
-        "@aws-sdk/middleware-retry": "3.272.0",
-        "@aws-sdk/middleware-sdk-sts": "3.272.0",
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/middleware-signing": "3.272.0",
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/middleware-user-agent": "3.272.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/node-http-handler": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/smithy-client": "3.279.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-        "@aws-sdk/util-defaults-mode-node": "3.279.0",
-        "@aws-sdk/util-endpoints": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "@aws-sdk/util-user-agent-browser": "3.272.0",
-        "@aws-sdk/util-user-agent-node": "3.272.0",
-        "@aws-sdk/util-utf8": "3.254.0",
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/credential-provider-node": "3.321.1",
+        "@aws-sdk/fetch-http-handler": "3.310.0",
+        "@aws-sdk/hash-node": "3.310.0",
+        "@aws-sdk/invalid-dependency": "3.310.0",
+        "@aws-sdk/middleware-content-length": "3.310.0",
+        "@aws-sdk/middleware-endpoint": "3.310.0",
+        "@aws-sdk/middleware-host-header": "3.310.0",
+        "@aws-sdk/middleware-logger": "3.310.0",
+        "@aws-sdk/middleware-recursion-detection": "3.310.0",
+        "@aws-sdk/middleware-retry": "3.310.0",
+        "@aws-sdk/middleware-sdk-sts": "3.310.0",
+        "@aws-sdk/middleware-serde": "3.310.0",
+        "@aws-sdk/middleware-signing": "3.310.0",
+        "@aws-sdk/middleware-stack": "3.310.0",
+        "@aws-sdk/middleware-user-agent": "3.319.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/node-http-handler": "3.321.1",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/smithy-client": "3.316.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+        "@aws-sdk/util-defaults-mode-node": "3.316.0",
+        "@aws-sdk/util-endpoints": "3.319.0",
+        "@aws-sdk/util-retry": "3.310.0",
+        "@aws-sdk/util-user-agent-browser": "3.310.0",
+        "@aws-sdk/util-user-agent-node": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
         "fast-xml-parser": "4.1.2",
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/config-resolver": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.272.0.tgz",
-      "integrity": "sha512-Dr4CffRVNsOp3LRNdpvcH6XuSgXOSLblWliCy/5I86cNl567KVMxujVx6uPrdTXYs2h1rt3MNl6jQGnAiJeTbw==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.310.0.tgz",
+      "integrity": "sha512-8vsT+/50lOqfDxka9m/rRt6oxv1WuGZoP8oPMk0Dt+TxXMbAzf4+rejBgiB96wshI1k3gLokYRjSQZn+dDtT8g==",
       "dependencies": {
-        "@aws-sdk/signature-v4": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-config-provider": "3.310.0",
+        "@aws-sdk/util-middleware": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.272.0.tgz",
-      "integrity": "sha512-QI65NbLnKLYHyTYhXaaUrq6eVsCCrMUb05WDA7+TJkWkjXesovpjc8vUKgFiLSxmgKmb2uOhHNcDyObKMrYQFw==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.310.0.tgz",
+      "integrity": "sha512-vvIPQpI16fj95xwS7M3D48F7QhZJBnnCgB5lR+b7So+vsG9ibm1mZRVGzVpdxCvgyOhHFbvrby9aalNJmmIP1A==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.272.0.tgz",
-      "integrity": "sha512-wwAfVY1jTFQEfxVfdYD5r5ieYGl+0g4nhekVxNMqE8E1JeRDd18OqiwAflzpgBIqxfqvCUkf+vl5JYyacMkNAQ==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.310.0.tgz",
+      "integrity": "sha512-baxK7Zp6dai5AGW01FIW27xS2KAaPUmKLIXv5SvFYsUgXXvNW55im4uG3b+2gA0F7V+hXvVBH08OEqmwW6we5w==",
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.281.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.281.0.tgz",
-      "integrity": "sha512-H99nhMhHImQKgNhHKYc6usTS6UK8KzCcVGpILLVTuP97YlrYAMFAVstA3Xk6mZ28JAbHVXvI6vJjkMNOzCSKCA==",
+      "version": "3.321.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.321.1.tgz",
+      "integrity": "sha512-prndSVQhiikNaI40bYnM2Q8PkC35FCwhbQnBk6KXNvdtfo9RqatMC639F+6oryb3BuMy++Ij4Yoi8WnPBs5Sww==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.272.0",
-        "@aws-sdk/credential-provider-imds": "3.272.0",
-        "@aws-sdk/credential-provider-process": "3.272.0",
-        "@aws-sdk/credential-provider-sso": "3.281.0",
-        "@aws-sdk/credential-provider-web-identity": "3.272.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/credential-provider-env": "3.310.0",
+        "@aws-sdk/credential-provider-imds": "3.310.0",
+        "@aws-sdk/credential-provider-process": "3.310.0",
+        "@aws-sdk/credential-provider-sso": "3.321.1",
+        "@aws-sdk/credential-provider-web-identity": "3.310.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.281.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.281.0.tgz",
-      "integrity": "sha512-jhddd+lJp8G8hBJ+6glmXjfWJT3nxiE1aliH3fBC4RR3D+1kRXc99Xg6mbUb8bm+GrVZ4gzfiqSgg+ByKjd7xA==",
+      "version": "3.321.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.321.1.tgz",
+      "integrity": "sha512-5B1waOwSvY2JMLGRebo7IUqnTaGoCnby9cRbG/dhi7Ke97M3V8380S9THDJ/bktjL8zHEVfBVZy7HhXHzhSjEg==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.272.0",
-        "@aws-sdk/credential-provider-imds": "3.272.0",
-        "@aws-sdk/credential-provider-ini": "3.281.0",
-        "@aws-sdk/credential-provider-process": "3.272.0",
-        "@aws-sdk/credential-provider-sso": "3.281.0",
-        "@aws-sdk/credential-provider-web-identity": "3.272.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/credential-provider-env": "3.310.0",
+        "@aws-sdk/credential-provider-imds": "3.310.0",
+        "@aws-sdk/credential-provider-ini": "3.321.1",
+        "@aws-sdk/credential-provider-process": "3.310.0",
+        "@aws-sdk/credential-provider-sso": "3.321.1",
+        "@aws-sdk/credential-provider-web-identity": "3.310.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.272.0.tgz",
-      "integrity": "sha512-hiCAjWWm2PeBFp5cjkxqyam/XADjiS+e7GzwC34TbZn3LisS0uoweLojj9tD11NnnUhyhbLteUvu5+rotOLwrg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.310.0.tgz",
+      "integrity": "sha512-h73sg6GPMUWC+3zMCbA1nZ2O03nNJt7G96JdmnantiXBwHpRKWW8nBTLzx5uhXn6hTuTaoQRP/P+oxQJKYdMmA==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.281.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.281.0.tgz",
-      "integrity": "sha512-IqJnpXuLpJYoSCf/Rt66/CPVTjfkam3z9+ZvlQJV+VbK+vGj276qEtTmSN3XPZZgF1XbWptvkzIWDszLhHiZmg==",
+      "version": "3.321.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.321.1.tgz",
+      "integrity": "sha512-kg0rc1OacJFgAvmZj0TOu+BSc+yRdnC5dO/RAag3XU6+hlQI5/C080RQp9Qj6V7ga0HtAJMRwJcUlCPA3RJPug==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.281.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/token-providers": "3.281.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/client-sso": "3.321.1",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/token-providers": "3.321.1",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.272.0.tgz",
-      "integrity": "sha512-ImrHMkcgneGa/HadHAQXPwOrX26sAKuB8qlMxZF/ZCM2B55u8deY+ZVkVuraeKb7YsahMGehPFOfRAF6mvFI5Q==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.310.0.tgz",
+      "integrity": "sha512-H4SzuZXILNhK6/IR1uVvsUDZvzc051hem7GLyYghBCu8mU+tq28YhKE8MfSroi6eL2e5Vujloij1OM2EQQkPkw==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.272.0.tgz",
-      "integrity": "sha512-1Qhm9e0RbS1Xf4CZqUbQyUMkDLd7GrsRXWIvm9b86/vgeV8/WnjO3CMue9D51nYgcyQORhYXv6uVjAYCWbUExA==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.310.0.tgz",
+      "integrity": "sha512-Bi9vIwzdkw1zMcvi/zGzlWS9KfIEnAq4NNhsnCxbQ4OoIRU9wvU+WGZdBBhxg0ZxZmpp1j1aZhU53lLjA07MHw==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/querystring-builder": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/querystring-builder": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/hash-node": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.272.0.tgz",
-      "integrity": "sha512-40dwND+iAm3VtPHPZu7/+CIdVJFk2s0cWZt1lOiMPMSXycSYJ45wMk7Lly3uoqRx0uWfFK5iT2OCv+fJi5jTng==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.310.0.tgz",
+      "integrity": "sha512-NvE2fhRc8GRwCXBfDehxVAWCmVwVMILliAKVPAEr4yz2CkYs0tqU51S48x23dtna07H4qHtgpeNqVTthcIQOEQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.272.0.tgz",
-      "integrity": "sha512-ysW6wbjl1Y78txHUQ/Tldj2Rg1BI7rpMO9B9xAF6yAX3mQ7t6SUPQG/ewOGvH2208NBIl3qP5e/hDf0Q6r/1iw==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.310.0.tgz",
+      "integrity": "sha512-1s5RG5rSPXoa/aZ/Kqr5U/7lqpx+Ry81GprQ2bxWqJvWQIJ0IRUwo5pk8XFxbKVr/2a+4lZT/c3OGoBOM1yRRA==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
+      "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.272.0.tgz",
-      "integrity": "sha512-sAbDZSTNmLX+UTGwlUHJBWy0QGQkiClpHwVFXACon+aG0ySLNeRKEVYs6NCPYldw4cj6hveLUn50cX44ukHErw==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.310.0.tgz",
+      "integrity": "sha512-P8tQZxgDt6CAh1wd/W6WPzjc+uWPJwQkm+F7rAwRlM+k9q17HrhnksGDKcpuuLyIhPQYdmOMIkpKVgXGa4avhQ==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/middleware-endpoint": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.272.0.tgz",
-      "integrity": "sha512-Dk3JVjj7SxxoUKv3xGiOeBksvPtFhTDrVW75XJ98Ymv8gJH5L1sq4hIeJAHRKogGiRFq2J73mnZSlM9FVXEylg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.310.0.tgz",
+      "integrity": "sha512-Z+N2vOL8K354/lstkClxLLsr6hCpVRh+0tCMXrVj66/NtKysCEZ/0b9LmqOwD9pWHNiI2mJqXwY0gxNlKAroUg==",
       "dependencies": {
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/signature-v4": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/middleware-serde": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-middleware": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.278.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.278.0.tgz",
-      "integrity": "sha512-oTkF3exy89KE8NgSeXFwD+0H0GRKL2qUw92t3caEj7+4KzU/0m3t7NtKlq2NLRtTJhZ/izYRpV536oogLzGm3g==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.310.0.tgz",
+      "integrity": "sha512-QWSA+46/hXorXyWa61ic2K7qZzwHTiwfk2e9mRRjeIRepUgI3qxFjsYqrWtrOGBjmFmq0pYIY8Bb/DCJuQqcoA==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.272.0.tgz",
-      "integrity": "sha512-u2SQ0hWrFwxbxxYMG5uMEgf01pQY5jauK/LYWgGIvuCmFgiyRQQP3oN7kkmsxnS9MWmNmhbyQguX2NY02s5e9w==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.310.0.tgz",
+      "integrity": "sha512-Lurm8XofrASBRnAVtiSNuDSRsRqPNg27RIFLLsLp/pqog9nFJ0vz0kgdb9S5Z+zw83Mm+UlqOe6D8NTUNp4fVg==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.272.0.tgz",
-      "integrity": "sha512-Gp/eKWeUWVNiiBdmUM2qLkBv+VLSJKoWAO+aKmyxxwjjmWhE0FrfA1NQ1a3g+NGMhRbAfQdaYswRAKsul70ISg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.310.0.tgz",
+      "integrity": "sha512-SuB75/xk/gyue24gkriTwO2jFd7YcUGZDClQYuRejgbXSa3CO0lWyawQtfLcSSEBp9izrEVXuFH24K1eAft5nQ==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.272.0.tgz",
-      "integrity": "sha512-pCGvHM7C76VbO/dFerH+Vwf7tGv7j+e+eGrvhQ35mRghCtfIou/WMfTZlD1TNee93crrAQQVZKjtW3dMB3WCzg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.310.0.tgz",
+      "integrity": "sha512-oTPsRy2W4s+dfxbJPW7Km+hHtv/OMsNsVfThAq8DDYKC13qlr1aAyOqGLD+dpBy2aKe7ss517Sy2HcHtHqm7/g==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/service-error-classification": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-middleware": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "tslib": "^2.3.1",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/service-error-classification": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-middleware": "3.310.0",
+        "@aws-sdk/util-retry": "3.310.0",
+        "tslib": "^2.5.0",
         "uuid": "^8.3.2"
       },
       "engines": {
@@ -2621,320 +2790,394 @@
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.272.0.tgz",
-      "integrity": "sha512-VvYPg7LrDIjUOWueSzo2wBzcNG7dw+cmzV6zAKaLxf0RC5jeAP4hE0OzDiiZfDrjNghEzgq/V+0NO+LewqYL9Q==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.310.0.tgz",
+      "integrity": "sha512-+5PFwlYNLvLLIfw0ASAoWV/iIF8Zv6R6QGtyP0CclhRSvNjgbQDVnV0g95MC5qvh+GB/Yjlkt8qAjLSPjHfsrQ==",
       "dependencies": {
-        "@aws-sdk/middleware-signing": "3.272.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/signature-v4": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/middleware-signing": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.272.0.tgz",
-      "integrity": "sha512-kW1uOxgPSwtXPB5rm3QLdWomu42lkYpQL94tM1BjyFOWmBLO2lQhk5a7Dw6HkTozT9a+vxtscLChRa6KZe61Hw==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.310.0.tgz",
+      "integrity": "sha512-RNeeTVWSLTaentUeCgQKZhAl+C6hxtwD78cQWS10UymWpQFwbaxztzKUu4UQS5xA2j6PxwPRRUjqa4jcFjfLsg==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.272.0.tgz",
-      "integrity": "sha512-4LChFK4VAR91X+dupqM8fQqYhFGE0G4Bf9rQlVTgGSbi2KUOmpqXzH0/WKE228nKuEhmH8+Qd2VPSAE2JcyAUA==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.310.0.tgz",
+      "integrity": "sha512-f9mKq+XMdW207Af3hKjdTnpNhdtwqWuvFs/ZyXoOkp/g1MY1O6L23Jy6i52m29LxbT4AuNRG1oKODfXM0vYVjQ==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/signature-v4": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-middleware": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/signature-v4": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-middleware": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.272.0.tgz",
-      "integrity": "sha512-jhwhknnPBGhfXAGV5GXUWfEhDFoP/DN8MPCO2yC5OAxyp6oVJ8lTPLkZYMTW5VL0c0eG44dXpF4Ib01V+PlDrQ==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.310.0.tgz",
+      "integrity": "sha512-010O1PD+UAcZVKRvqEusE1KJqN96wwrf6QsqbRM0ywsKQ21NDweaHvEDlds2VHpgmofxkRLRu/IDrlPkKRQrRg==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.272.0.tgz",
-      "integrity": "sha512-Qy7/0fsDJxY5l0bEk7WKDfqb4Os/sCAgFR2zEvrhDtbkhYPf72ysvg/nRUTncmCbo8tOok4SJii2myk8KMfjjw==",
+      "version": "3.319.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.319.0.tgz",
+      "integrity": "sha512-ytaLx2dlR5AdMSne6FuDCISVg8hjyKj+cHU20b2CRA/E/z+XXrLrssp4JrCgizRKPPUep0psMIa22Zd6osTT5Q==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-endpoints": "3.319.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.272.0.tgz",
-      "integrity": "sha512-YYCIBh9g1EQo7hm2l22HX5Yr9RoPQ2RCvhzKvF1n1e8t1QH4iObQrYUtqHG4khcm64Cft8C5MwZmgzHbya5Z6Q==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.310.0.tgz",
+      "integrity": "sha512-T/Pp6htc6hq/Cq+MLNDSyiwWCMVF6GqbBbXKVlO5L8rdHx4sq9xPdoPveZhGWrxvkanjA6eCwUp6E0riBOSVng==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.272.0.tgz",
-      "integrity": "sha512-VrW9PjhhngeyYp4yGYPe5S0vgZH6NwU3Po9xAgayUeE37Inr7LS1YteFMHdpgsUUeNXnh7d06CXqHo1XjtqOKA==",
+      "version": "3.321.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.321.1.tgz",
+      "integrity": "sha512-DdQBrtFFDNtzphJIN3s93Vf+qd9LHSzH6WTQRrWoXhTDMHDzSI2Cn+c5KWfk89Nggp/n3+OTwUPQeCiBT5EBuw==",
       "dependencies": {
-        "@aws-sdk/abort-controller": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/querystring-builder": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/abort-controller": "3.310.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/querystring-builder": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/property-provider": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.272.0.tgz",
-      "integrity": "sha512-V1pZTaH5eqpAt8O8CzbItHhOtzIfFuWymvwZFkAtwKuaHpnl7jjrTouV482zoq8AD/fF+VVSshwBKYA7bhidIw==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.310.0.tgz",
+      "integrity": "sha512-3lxDb0akV6BBzmFe4nLPaoliQbAifyWJhuvuDOu7e8NzouvpQXs0275w9LePhhcgjKAEVXUIse05ZW2DLbxo/g==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.272.0.tgz",
-      "integrity": "sha512-4JQ54v5Yn08jspNDeHo45CaSn1CvTJqS1Ywgr79eU6jBExtguOWv6LNtwVSBD9X37v88iqaxt8iu1Z3pZZAJeg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.310.0.tgz",
+      "integrity": "sha512-fgZ1aw/irQtnrsR58pS8ThKOWo57Py3xX6giRvwSgZDEcxHfVzuQjy9yPuV++v04fdmdtgpbGf8WfvAAJ11yXQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.272.0.tgz",
-      "integrity": "sha512-ndo++7GkdCj5tBXE6rGcITpSpZS4PfyV38wntGYAlj9liL1omk3bLZRY6uzqqkJpVHqbg2fD7O2qHNItzZgqhw==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.310.0.tgz",
+      "integrity": "sha512-ZHH8GV/80+pWGo7DzsvwvXR5xVxUHXUvPJPFAkhr6nCf78igdoF8gR10ScFoEKbtEapoNTaZlKHPXxpD8aPG7A==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.272.0.tgz",
-      "integrity": "sha512-5oS4/9n6N1LZW9tI3qq/0GnCuWoOXRgcHVB+AJLRBvDbEe+GI+C/xK1tKLsfpDNgsQJHc4IPQoIt4megyZ/1+A==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.310.0.tgz",
+      "integrity": "sha512-YkIznoP6lsiIUHinx++/lbb3tlMURGGqMpo0Pnn32zYzGrJXA6eC3D0as2EcMjo55onTfuLcIiX4qzXes2MYOA==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.272.0.tgz",
-      "integrity": "sha512-REoltM1LK9byyIufLqx9znhSolPcHQgVHIA2S0zu5sdt5qER4OubkLAXuo4MBbisUTmh8VOOvIyUb5ijZCXq1w==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.310.0.tgz",
+      "integrity": "sha512-PuyC7k3qfIKeH2LCnDwbttMOKq3qAx4buvg0yfnJtQOz6t1AR8gsnAq0CjKXXyfkXwNKWTqCpE6lVNUIkXgsMw==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.272.0.tgz",
-      "integrity": "sha512-lzFPohp5sy2XvwFjZIzLVCRpC0i5cwBiaXmFzXYQZJm6FSCszHO4ax+m9yrtlyVFF/2YPWl+/bzNthy4aJtseA==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.310.0.tgz",
+      "integrity": "sha512-N0q9pG0xSjQwc690YQND5bofm+4nfUviQ/Ppgan2kU6aU0WUq8KwgHJBto/YEEI+VlrME30jZJnxtOvcZJc2XA==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/signature-v4": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.272.0.tgz",
-      "integrity": "sha512-pWxnHG1NqJWMwlhJ6NHNiUikOL00DHROmxah6krJPMPq4I3am2KY2Rs/8ouWhnEXKaHAv4EQhSALJ+7Mq5S4/A==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.310.0.tgz",
+      "integrity": "sha512-1M60P1ZBNAjCFv9sYW29OF6okktaeibWyW3lMXqzoHF70lHBZh+838iUchznXUA5FLabfn4jBFWMRxlAXJUY2Q==",
       "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-middleware": "3.272.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "@aws-sdk/util-middleware": "3.310.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/smithy-client": {
-      "version": "3.279.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.279.0.tgz",
-      "integrity": "sha512-ZcYWUQDGAYN6NXRpJuSn46PetrpPCA6TrDVwP9+3pERzTXZ66npXoG2XhHjNrOXy/Ted5A3OxKrM4/zLu9tK3A==",
+      "version": "3.316.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.316.0.tgz",
+      "integrity": "sha512-6YXOKbRnXeS8r8RWzuL6JMBolDYM5Wa4fD/VY6x/wK78i2xErHOvqzHgyyeLI1MMw4uqyd4wRNJNWC9TMPduXw==",
       "dependencies": {
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/middleware-stack": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/token-providers": {
-      "version": "3.281.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.281.0.tgz",
-      "integrity": "sha512-36Vg/F6Edm7qdjcTeNVON+sK2edgHhmhTtAEjWcuUk5AX/Et+Ate/A2N8HD3nxwlAcgidfnBC9SHYJatbhcEnQ==",
+      "version": "3.321.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.321.1.tgz",
+      "integrity": "sha512-I1sXS4qXirSvgvrOIPf+e1D7GvC83DdeyMxHZvuhHgeMCqDAzToS8OLxOX0enN9xZRHWAQYja8xyeGbDL2I0Zw==",
       "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.281.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/client-sso-oidc": "3.321.1",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/types": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.272.0.tgz",
-      "integrity": "sha512-MmmL6vxMGP5Bsi+4wRx4mxYlU/LX6M0noOXrDh/x5FfG7/4ZOar/nDxqDadhJtNM88cuWVHZWY59P54JzkGWmA==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.310.0.tgz",
+      "integrity": "sha512-j8eamQJ7YcIhw7fneUfs8LYl3t01k4uHi4ZDmNRgtbmbmTTG3FZc2MotStZnp3nZB6vLiPF1o5aoJxWVvkzS6A==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/url-parser": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.272.0.tgz",
-      "integrity": "sha512-vX/Tx02PlnQ/Kgtf5TnrNDHPNbY+amLZjW0Z1d9vzAvSZhQ4i9Y18yxoRDIaDTCNVRDjdhV8iuctW+05PB5JtQ==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.310.0.tgz",
+      "integrity": "sha512-mCLnCaSB9rQvAgx33u0DujLvr4d5yEm/W5r789GblwwQnlNXedVu50QRizMLTpltYWyAUoXjJgQnJHmJMaKXhw==",
       "dependencies": {
-        "@aws-sdk/querystring-parser": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/querystring-parser": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/util-base64": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
+      "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
+      "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
+      "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
+      "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
+      "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.279.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.279.0.tgz",
-      "integrity": "sha512-RnchYRrpapTT5Hu23LOfk6e8RMVq0kUzho6xA6TJj1a4uGxkcRMvgzPipCq1P5uHu0mrkQBg9pGPEVNOUs38/Q==",
+      "version": "3.316.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.316.0.tgz",
+      "integrity": "sha512-6FSqLhYmaihtH2n1s4b2rlLW0ABU8N6VZIfzLfe2ING4PF0MzfaMMhnTFUHVXfKCVGoR8yP6iyFTRCyHGVEL1w==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">= 10.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.279.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.279.0.tgz",
-      "integrity": "sha512-A2NB10xReWC+GSnOivKGZ9rnljIZdEP8WMCQQEnA6DJNI19AUFF/O9QJ9y+cHGLKEms7jH86Y99wShdpzAK+Jw==",
+      "version": "3.316.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.316.0.tgz",
+      "integrity": "sha512-dkYy10hdjPSScXXvnjGpZpnJxllkb6ICHgLMwZ4JczLHhPM12T/4PQ758YN8HS+muiYDGX1Bl2z1jd/bMcewBQ==",
       "dependencies": {
-        "@aws-sdk/config-resolver": "3.272.0",
-        "@aws-sdk/credential-provider-imds": "3.272.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/credential-provider-imds": "3.310.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">= 10.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.272.0.tgz",
-      "integrity": "sha512-c4MPUaJt2G6gGpoiwIOqDfUa98c1J63RpYvf/spQEKOtC/tF5Gfqlxuq8FnAl5lHnrqj1B9ZXLLxFhHtDR0IiQ==",
+      "version": "3.319.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.319.0.tgz",
+      "integrity": "sha512-3I64UMoYA2e2++oOUJXRcFtYLpLylnZFRltWfPo1B3dLlf+MIWat9djT+mMus+hW1ntLsvAIVu1hLVePJC0gvw==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
+      "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/util-middleware": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.272.0.tgz",
-      "integrity": "sha512-Abw8m30arbwxqmeMMha5J11ESpHUNmCeSqSzE8/C4B8jZQtHY4kq7f+upzcNIQ11lsd+uzBEzNG3+dDRi0XOJQ==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.310.0.tgz",
+      "integrity": "sha512-FTSUKL/eRb9X6uEZClrTe27QFXUNNp7fxYrPndZwk1hlaOP5ix+MIHBcI7pIiiY/JPfOUmPyZOu+HetlFXjWog==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/util-retry": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.272.0.tgz",
-      "integrity": "sha512-Ngha5414LR4gRHURVKC9ZYXsEJhMkm+SJ+44wlzOhavglfdcKKPUsibz5cKY1jpUV7oKECwaxHWpBB8r6h+hOg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.310.0.tgz",
+      "integrity": "sha512-FwWGhCBLfoivTMUHu1LIn4NjrN9JLJ/aX5aZmbcPIOhZVFJj638j0qDgZXyfvVqBuBZh7M8kGq0Oahy3dp69OA==",
       "dependencies": {
-        "@aws-sdk/service-error-classification": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/service-error-classification": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.272.0.tgz",
-      "integrity": "sha512-Lp5QX5bH6uuwBlIdr7w7OAcAI50ttyskb++yUr9i+SPvj6RI2dsfIBaK4mDg1qUdM5LeUdvIyqwj3XHjFKAAvA==",
+    "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
+      "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.310.0.tgz",
+      "integrity": "sha512-yU/4QnHHuQ5z3vsUqMQVfYLbZGYwpYblPiuZx4Zo9+x0PBkNjYMqctdDcrpoH9Z2xZiDN16AmQGK1tix117ZKw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video-archived-media/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.272.0.tgz",
-      "integrity": "sha512-ljK+R3l+Q1LIHrcR+Knhk0rmcSkfFadZ8V+crEGpABf/QUQRg7NkZMsoe814tfBO5F7tMxo8wwwSdaVNNHtoRA==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.310.0.tgz",
+      "integrity": "sha512-Ra3pEl+Gn2BpeE7KiDGpi4zj7WJXZA5GXnGo3mjbi9+Y3zrbuhJAbdZO3mO/o7xDgMC6ph4xCTbaSGzU6b6EDg==",
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -3753,6 +3996,18 @@
         "aws-crt": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@aws-sdk/client-kinesis-video/node_modules/@aws-sdk/util-utf8": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.254.0.tgz",
+      "integrity": "sha512-14Kso/eIt5/qfIBmhEL9L1IfyUqswjSTqO2mY7KOzUZ9SZbwn3rpxmtkhmATkRjD7XIlLKaxBkI7tU9Zjzj8Kw==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kinesis-video/node_modules/fast-xml-parser": {
@@ -4595,6 +4850,33 @@
         "node": ">= 14.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-stream-browser": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.272.0.tgz",
+      "integrity": "sha512-vD514YffKxBjV/erjUNgkXcb/mzXAz3uk/KUFMXsodo3cA4Z8WxL4P0p1O09FVuJlNa0gZ8mhFPNzNOekh31GA==",
+      "dependencies": {
+        "@aws-sdk/fetch-http-handler": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-stream-node": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.272.0.tgz",
+      "integrity": "sha512-s7dGeM1ImzihqBKgrpaeZokLnPUk3H4Et5oiM+t+TpRxotXTecJPyuD0p76HRgO8KSXfVT5Nxw/FoHXqj1fiMg==",
+      "dependencies": {
+        "@aws-sdk/node-http-handler": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-browser": {
       "version": "3.272.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.272.0.tgz",
@@ -4626,6 +4908,31 @@
         }
       }
     },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-utf8": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.254.0.tgz",
+      "integrity": "sha512-14Kso/eIt5/qfIBmhEL9L1IfyUqswjSTqO2mY7KOzUZ9SZbwn3rpxmtkhmATkRjD7XIlLKaxBkI7tU9Zjzj8Kw==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-waiter": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.272.0.tgz",
+      "integrity": "sha512-N25/XsJ2wkPh1EgkFyb/GRgfHDityScfD49Hk1AwJWpfetzgkcEtWdeW4IuPymXlSKhrm5L+SBw49USxo9kBag==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-s3/node_modules/fast-xml-parser": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
@@ -4642,45 +4949,45 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.281.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.281.0.tgz",
-      "integrity": "sha512-vL+LygNDoCja/47pFwSnI3tCWfy5SGHlz6C1whcszmfl81gXyuHNlAK8RXVRiKhnD11zmCsHJhZyYSfTz5RErQ==",
+      "version": "3.321.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.321.1.tgz",
+      "integrity": "sha512-OlZzn7I2PYaTRJycK88NeB++VwQqnEHbnHMhKKcFkjUzHD3w1hZkkHr0T5XbgDtXmWZUW3u24+3BtV1xtjAzHQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.281.0",
-        "@aws-sdk/config-resolver": "3.272.0",
-        "@aws-sdk/credential-provider-node": "3.281.0",
-        "@aws-sdk/fetch-http-handler": "3.272.0",
-        "@aws-sdk/hash-node": "3.272.0",
-        "@aws-sdk/invalid-dependency": "3.272.0",
-        "@aws-sdk/middleware-content-length": "3.272.0",
-        "@aws-sdk/middleware-endpoint": "3.272.0",
-        "@aws-sdk/middleware-host-header": "3.278.0",
-        "@aws-sdk/middleware-logger": "3.272.0",
-        "@aws-sdk/middleware-recursion-detection": "3.272.0",
-        "@aws-sdk/middleware-retry": "3.272.0",
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/middleware-signing": "3.272.0",
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/middleware-user-agent": "3.272.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/node-http-handler": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/smithy-client": "3.279.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-        "@aws-sdk/util-defaults-mode-node": "3.279.0",
-        "@aws-sdk/util-endpoints": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "@aws-sdk/util-user-agent-browser": "3.272.0",
-        "@aws-sdk/util-user-agent-node": "3.272.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1",
+        "@aws-sdk/client-sts": "3.321.1",
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/credential-provider-node": "3.321.1",
+        "@aws-sdk/fetch-http-handler": "3.310.0",
+        "@aws-sdk/hash-node": "3.310.0",
+        "@aws-sdk/invalid-dependency": "3.310.0",
+        "@aws-sdk/middleware-content-length": "3.310.0",
+        "@aws-sdk/middleware-endpoint": "3.310.0",
+        "@aws-sdk/middleware-host-header": "3.310.0",
+        "@aws-sdk/middleware-logger": "3.310.0",
+        "@aws-sdk/middleware-recursion-detection": "3.310.0",
+        "@aws-sdk/middleware-retry": "3.310.0",
+        "@aws-sdk/middleware-serde": "3.310.0",
+        "@aws-sdk/middleware-signing": "3.310.0",
+        "@aws-sdk/middleware-stack": "3.310.0",
+        "@aws-sdk/middleware-user-agent": "3.319.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/node-http-handler": "3.321.1",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/smithy-client": "3.316.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+        "@aws-sdk/util-defaults-mode-node": "3.316.0",
+        "@aws-sdk/util-endpoints": "3.319.0",
+        "@aws-sdk/util-retry": "3.310.0",
+        "@aws-sdk/util-user-agent-browser": "3.310.0",
+        "@aws-sdk/util-user-agent-node": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0",
         "uuid": "^8.3.2"
       },
       "engines": {
@@ -4764,387 +5071,394 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/abort-controller": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.272.0.tgz",
-      "integrity": "sha512-s2TV3phapcTwZNr4qLxbfuQuE9ZMP4RoJdkvRRCkKdm6jslsWLJf2Zlcxti/23hOlINUMYv2iXE2pftIgWGdpg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.310.0.tgz",
+      "integrity": "sha512-v1zrRQxDLA1MdPim159Vx/CPHqsB4uybSxRi1CnfHO5ZjHryx3a5htW2gdGAykVCul40+yJXvfpufMrELVxH+g==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/client-sso": {
-      "version": "3.281.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.281.0.tgz",
-      "integrity": "sha512-3RvO5zClQhu37w9VMLoHPGk58S3y8Spb7XX8rW51bm5TUglYQskQ0X2VLEUW/7ZGx/peokHws9Z9+w5yGq5sdA==",
+      "version": "3.321.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.321.1.tgz",
+      "integrity": "sha512-ecoT4tBGtRJR5G7oLBTMXZmgZZlff1amhSdKPEtkWxv6kWc8VPb5rRuRgVPsDR9HuesI6ZVlODptvGtnfkIJwA==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.272.0",
-        "@aws-sdk/fetch-http-handler": "3.272.0",
-        "@aws-sdk/hash-node": "3.272.0",
-        "@aws-sdk/invalid-dependency": "3.272.0",
-        "@aws-sdk/middleware-content-length": "3.272.0",
-        "@aws-sdk/middleware-endpoint": "3.272.0",
-        "@aws-sdk/middleware-host-header": "3.278.0",
-        "@aws-sdk/middleware-logger": "3.272.0",
-        "@aws-sdk/middleware-recursion-detection": "3.272.0",
-        "@aws-sdk/middleware-retry": "3.272.0",
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/middleware-user-agent": "3.272.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/node-http-handler": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/smithy-client": "3.279.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-        "@aws-sdk/util-defaults-mode-node": "3.279.0",
-        "@aws-sdk/util-endpoints": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "@aws-sdk/util-user-agent-browser": "3.272.0",
-        "@aws-sdk/util-user-agent-node": "3.272.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/fetch-http-handler": "3.310.0",
+        "@aws-sdk/hash-node": "3.310.0",
+        "@aws-sdk/invalid-dependency": "3.310.0",
+        "@aws-sdk/middleware-content-length": "3.310.0",
+        "@aws-sdk/middleware-endpoint": "3.310.0",
+        "@aws-sdk/middleware-host-header": "3.310.0",
+        "@aws-sdk/middleware-logger": "3.310.0",
+        "@aws-sdk/middleware-recursion-detection": "3.310.0",
+        "@aws-sdk/middleware-retry": "3.310.0",
+        "@aws-sdk/middleware-serde": "3.310.0",
+        "@aws-sdk/middleware-stack": "3.310.0",
+        "@aws-sdk/middleware-user-agent": "3.319.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/node-http-handler": "3.321.1",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/smithy-client": "3.316.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+        "@aws-sdk/util-defaults-mode-node": "3.316.0",
+        "@aws-sdk/util-endpoints": "3.319.0",
+        "@aws-sdk/util-retry": "3.310.0",
+        "@aws-sdk/util-user-agent-browser": "3.310.0",
+        "@aws-sdk/util-user-agent-node": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.281.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.281.0.tgz",
-      "integrity": "sha512-P6zf9pDuxApVoCYStAg7L8BU9AcWI8PxfLSX4r2WnmcQropxzPJ3op1j9nvbwwBDMFWephijVY4AVp8MqPcPyg==",
+      "version": "3.321.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.321.1.tgz",
+      "integrity": "sha512-PBVfHQbyrsfzbnO6u9d9Sik8JlXGLhHj3zLd87iBkYXBdHwD5NuvwWu7OtjUtrHjP4SfzodVwfjmTbDAFqbtzw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.272.0",
-        "@aws-sdk/fetch-http-handler": "3.272.0",
-        "@aws-sdk/hash-node": "3.272.0",
-        "@aws-sdk/invalid-dependency": "3.272.0",
-        "@aws-sdk/middleware-content-length": "3.272.0",
-        "@aws-sdk/middleware-endpoint": "3.272.0",
-        "@aws-sdk/middleware-host-header": "3.278.0",
-        "@aws-sdk/middleware-logger": "3.272.0",
-        "@aws-sdk/middleware-recursion-detection": "3.272.0",
-        "@aws-sdk/middleware-retry": "3.272.0",
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/middleware-user-agent": "3.272.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/node-http-handler": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/smithy-client": "3.279.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-        "@aws-sdk/util-defaults-mode-node": "3.279.0",
-        "@aws-sdk/util-endpoints": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "@aws-sdk/util-user-agent-browser": "3.272.0",
-        "@aws-sdk/util-user-agent-node": "3.272.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/fetch-http-handler": "3.310.0",
+        "@aws-sdk/hash-node": "3.310.0",
+        "@aws-sdk/invalid-dependency": "3.310.0",
+        "@aws-sdk/middleware-content-length": "3.310.0",
+        "@aws-sdk/middleware-endpoint": "3.310.0",
+        "@aws-sdk/middleware-host-header": "3.310.0",
+        "@aws-sdk/middleware-logger": "3.310.0",
+        "@aws-sdk/middleware-recursion-detection": "3.310.0",
+        "@aws-sdk/middleware-retry": "3.310.0",
+        "@aws-sdk/middleware-serde": "3.310.0",
+        "@aws-sdk/middleware-stack": "3.310.0",
+        "@aws-sdk/middleware-user-agent": "3.319.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/node-http-handler": "3.321.1",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/smithy-client": "3.316.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+        "@aws-sdk/util-defaults-mode-node": "3.316.0",
+        "@aws-sdk/util-endpoints": "3.319.0",
+        "@aws-sdk/util-retry": "3.310.0",
+        "@aws-sdk/util-user-agent-browser": "3.310.0",
+        "@aws-sdk/util-user-agent-node": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/client-sts": {
-      "version": "3.281.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.281.0.tgz",
-      "integrity": "sha512-w8QomyhCVEArRcXgOkjbofiS/PLEKWRAyYBovjMS1cGhns2ZYJXFgHNgr3VGE54TghUc5dR1CqKuBKKM4ThrgA==",
+      "version": "3.321.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.321.1.tgz",
+      "integrity": "sha512-AB+N4a1TVEKl9Sd5O2TxTprEZp7Va6zPZLMraFAYMdmJVBmCmmwyBs7ygju685DpQ1dos5PRsKCRcossyY5pDQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.272.0",
-        "@aws-sdk/credential-provider-node": "3.281.0",
-        "@aws-sdk/fetch-http-handler": "3.272.0",
-        "@aws-sdk/hash-node": "3.272.0",
-        "@aws-sdk/invalid-dependency": "3.272.0",
-        "@aws-sdk/middleware-content-length": "3.272.0",
-        "@aws-sdk/middleware-endpoint": "3.272.0",
-        "@aws-sdk/middleware-host-header": "3.278.0",
-        "@aws-sdk/middleware-logger": "3.272.0",
-        "@aws-sdk/middleware-recursion-detection": "3.272.0",
-        "@aws-sdk/middleware-retry": "3.272.0",
-        "@aws-sdk/middleware-sdk-sts": "3.272.0",
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/middleware-signing": "3.272.0",
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/middleware-user-agent": "3.272.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/node-http-handler": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/smithy-client": "3.279.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-        "@aws-sdk/util-defaults-mode-node": "3.279.0",
-        "@aws-sdk/util-endpoints": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "@aws-sdk/util-user-agent-browser": "3.272.0",
-        "@aws-sdk/util-user-agent-node": "3.272.0",
-        "@aws-sdk/util-utf8": "3.254.0",
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/credential-provider-node": "3.321.1",
+        "@aws-sdk/fetch-http-handler": "3.310.0",
+        "@aws-sdk/hash-node": "3.310.0",
+        "@aws-sdk/invalid-dependency": "3.310.0",
+        "@aws-sdk/middleware-content-length": "3.310.0",
+        "@aws-sdk/middleware-endpoint": "3.310.0",
+        "@aws-sdk/middleware-host-header": "3.310.0",
+        "@aws-sdk/middleware-logger": "3.310.0",
+        "@aws-sdk/middleware-recursion-detection": "3.310.0",
+        "@aws-sdk/middleware-retry": "3.310.0",
+        "@aws-sdk/middleware-sdk-sts": "3.310.0",
+        "@aws-sdk/middleware-serde": "3.310.0",
+        "@aws-sdk/middleware-signing": "3.310.0",
+        "@aws-sdk/middleware-stack": "3.310.0",
+        "@aws-sdk/middleware-user-agent": "3.319.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/node-http-handler": "3.321.1",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/smithy-client": "3.316.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+        "@aws-sdk/util-defaults-mode-node": "3.316.0",
+        "@aws-sdk/util-endpoints": "3.319.0",
+        "@aws-sdk/util-retry": "3.310.0",
+        "@aws-sdk/util-user-agent-browser": "3.310.0",
+        "@aws-sdk/util-user-agent-node": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
         "fast-xml-parser": "4.1.2",
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/config-resolver": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.272.0.tgz",
-      "integrity": "sha512-Dr4CffRVNsOp3LRNdpvcH6XuSgXOSLblWliCy/5I86cNl567KVMxujVx6uPrdTXYs2h1rt3MNl6jQGnAiJeTbw==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.310.0.tgz",
+      "integrity": "sha512-8vsT+/50lOqfDxka9m/rRt6oxv1WuGZoP8oPMk0Dt+TxXMbAzf4+rejBgiB96wshI1k3gLokYRjSQZn+dDtT8g==",
       "dependencies": {
-        "@aws-sdk/signature-v4": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-config-provider": "3.310.0",
+        "@aws-sdk/util-middleware": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.272.0.tgz",
-      "integrity": "sha512-QI65NbLnKLYHyTYhXaaUrq6eVsCCrMUb05WDA7+TJkWkjXesovpjc8vUKgFiLSxmgKmb2uOhHNcDyObKMrYQFw==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.310.0.tgz",
+      "integrity": "sha512-vvIPQpI16fj95xwS7M3D48F7QhZJBnnCgB5lR+b7So+vsG9ibm1mZRVGzVpdxCvgyOhHFbvrby9aalNJmmIP1A==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.272.0.tgz",
-      "integrity": "sha512-wwAfVY1jTFQEfxVfdYD5r5ieYGl+0g4nhekVxNMqE8E1JeRDd18OqiwAflzpgBIqxfqvCUkf+vl5JYyacMkNAQ==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.310.0.tgz",
+      "integrity": "sha512-baxK7Zp6dai5AGW01FIW27xS2KAaPUmKLIXv5SvFYsUgXXvNW55im4uG3b+2gA0F7V+hXvVBH08OEqmwW6we5w==",
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.281.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.281.0.tgz",
-      "integrity": "sha512-H99nhMhHImQKgNhHKYc6usTS6UK8KzCcVGpILLVTuP97YlrYAMFAVstA3Xk6mZ28JAbHVXvI6vJjkMNOzCSKCA==",
+      "version": "3.321.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.321.1.tgz",
+      "integrity": "sha512-prndSVQhiikNaI40bYnM2Q8PkC35FCwhbQnBk6KXNvdtfo9RqatMC639F+6oryb3BuMy++Ij4Yoi8WnPBs5Sww==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.272.0",
-        "@aws-sdk/credential-provider-imds": "3.272.0",
-        "@aws-sdk/credential-provider-process": "3.272.0",
-        "@aws-sdk/credential-provider-sso": "3.281.0",
-        "@aws-sdk/credential-provider-web-identity": "3.272.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/credential-provider-env": "3.310.0",
+        "@aws-sdk/credential-provider-imds": "3.310.0",
+        "@aws-sdk/credential-provider-process": "3.310.0",
+        "@aws-sdk/credential-provider-sso": "3.321.1",
+        "@aws-sdk/credential-provider-web-identity": "3.310.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.281.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.281.0.tgz",
-      "integrity": "sha512-jhddd+lJp8G8hBJ+6glmXjfWJT3nxiE1aliH3fBC4RR3D+1kRXc99Xg6mbUb8bm+GrVZ4gzfiqSgg+ByKjd7xA==",
+      "version": "3.321.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.321.1.tgz",
+      "integrity": "sha512-5B1waOwSvY2JMLGRebo7IUqnTaGoCnby9cRbG/dhi7Ke97M3V8380S9THDJ/bktjL8zHEVfBVZy7HhXHzhSjEg==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.272.0",
-        "@aws-sdk/credential-provider-imds": "3.272.0",
-        "@aws-sdk/credential-provider-ini": "3.281.0",
-        "@aws-sdk/credential-provider-process": "3.272.0",
-        "@aws-sdk/credential-provider-sso": "3.281.0",
-        "@aws-sdk/credential-provider-web-identity": "3.272.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/credential-provider-env": "3.310.0",
+        "@aws-sdk/credential-provider-imds": "3.310.0",
+        "@aws-sdk/credential-provider-ini": "3.321.1",
+        "@aws-sdk/credential-provider-process": "3.310.0",
+        "@aws-sdk/credential-provider-sso": "3.321.1",
+        "@aws-sdk/credential-provider-web-identity": "3.310.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.272.0.tgz",
-      "integrity": "sha512-hiCAjWWm2PeBFp5cjkxqyam/XADjiS+e7GzwC34TbZn3LisS0uoweLojj9tD11NnnUhyhbLteUvu5+rotOLwrg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.310.0.tgz",
+      "integrity": "sha512-h73sg6GPMUWC+3zMCbA1nZ2O03nNJt7G96JdmnantiXBwHpRKWW8nBTLzx5uhXn6hTuTaoQRP/P+oxQJKYdMmA==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.281.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.281.0.tgz",
-      "integrity": "sha512-IqJnpXuLpJYoSCf/Rt66/CPVTjfkam3z9+ZvlQJV+VbK+vGj276qEtTmSN3XPZZgF1XbWptvkzIWDszLhHiZmg==",
+      "version": "3.321.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.321.1.tgz",
+      "integrity": "sha512-kg0rc1OacJFgAvmZj0TOu+BSc+yRdnC5dO/RAag3XU6+hlQI5/C080RQp9Qj6V7ga0HtAJMRwJcUlCPA3RJPug==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.281.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/token-providers": "3.281.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/client-sso": "3.321.1",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/token-providers": "3.321.1",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.272.0.tgz",
-      "integrity": "sha512-ImrHMkcgneGa/HadHAQXPwOrX26sAKuB8qlMxZF/ZCM2B55u8deY+ZVkVuraeKb7YsahMGehPFOfRAF6mvFI5Q==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.310.0.tgz",
+      "integrity": "sha512-H4SzuZXILNhK6/IR1uVvsUDZvzc051hem7GLyYghBCu8mU+tq28YhKE8MfSroi6eL2e5Vujloij1OM2EQQkPkw==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.272.0.tgz",
-      "integrity": "sha512-1Qhm9e0RbS1Xf4CZqUbQyUMkDLd7GrsRXWIvm9b86/vgeV8/WnjO3CMue9D51nYgcyQORhYXv6uVjAYCWbUExA==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.310.0.tgz",
+      "integrity": "sha512-Bi9vIwzdkw1zMcvi/zGzlWS9KfIEnAq4NNhsnCxbQ4OoIRU9wvU+WGZdBBhxg0ZxZmpp1j1aZhU53lLjA07MHw==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/querystring-builder": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/querystring-builder": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/hash-node": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.272.0.tgz",
-      "integrity": "sha512-40dwND+iAm3VtPHPZu7/+CIdVJFk2s0cWZt1lOiMPMSXycSYJ45wMk7Lly3uoqRx0uWfFK5iT2OCv+fJi5jTng==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.310.0.tgz",
+      "integrity": "sha512-NvE2fhRc8GRwCXBfDehxVAWCmVwVMILliAKVPAEr4yz2CkYs0tqU51S48x23dtna07H4qHtgpeNqVTthcIQOEQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.272.0.tgz",
-      "integrity": "sha512-ysW6wbjl1Y78txHUQ/Tldj2Rg1BI7rpMO9B9xAF6yAX3mQ7t6SUPQG/ewOGvH2208NBIl3qP5e/hDf0Q6r/1iw==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.310.0.tgz",
+      "integrity": "sha512-1s5RG5rSPXoa/aZ/Kqr5U/7lqpx+Ry81GprQ2bxWqJvWQIJ0IRUwo5pk8XFxbKVr/2a+4lZT/c3OGoBOM1yRRA==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
+      "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.272.0.tgz",
-      "integrity": "sha512-sAbDZSTNmLX+UTGwlUHJBWy0QGQkiClpHwVFXACon+aG0ySLNeRKEVYs6NCPYldw4cj6hveLUn50cX44ukHErw==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.310.0.tgz",
+      "integrity": "sha512-P8tQZxgDt6CAh1wd/W6WPzjc+uWPJwQkm+F7rAwRlM+k9q17HrhnksGDKcpuuLyIhPQYdmOMIkpKVgXGa4avhQ==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-endpoint": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.272.0.tgz",
-      "integrity": "sha512-Dk3JVjj7SxxoUKv3xGiOeBksvPtFhTDrVW75XJ98Ymv8gJH5L1sq4hIeJAHRKogGiRFq2J73mnZSlM9FVXEylg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.310.0.tgz",
+      "integrity": "sha512-Z+N2vOL8K354/lstkClxLLsr6hCpVRh+0tCMXrVj66/NtKysCEZ/0b9LmqOwD9pWHNiI2mJqXwY0gxNlKAroUg==",
       "dependencies": {
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/signature-v4": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/middleware-serde": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-middleware": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.278.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.278.0.tgz",
-      "integrity": "sha512-oTkF3exy89KE8NgSeXFwD+0H0GRKL2qUw92t3caEj7+4KzU/0m3t7NtKlq2NLRtTJhZ/izYRpV536oogLzGm3g==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.310.0.tgz",
+      "integrity": "sha512-QWSA+46/hXorXyWa61ic2K7qZzwHTiwfk2e9mRRjeIRepUgI3qxFjsYqrWtrOGBjmFmq0pYIY8Bb/DCJuQqcoA==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.272.0.tgz",
-      "integrity": "sha512-u2SQ0hWrFwxbxxYMG5uMEgf01pQY5jauK/LYWgGIvuCmFgiyRQQP3oN7kkmsxnS9MWmNmhbyQguX2NY02s5e9w==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.310.0.tgz",
+      "integrity": "sha512-Lurm8XofrASBRnAVtiSNuDSRsRqPNg27RIFLLsLp/pqog9nFJ0vz0kgdb9S5Z+zw83Mm+UlqOe6D8NTUNp4fVg==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.272.0.tgz",
-      "integrity": "sha512-Gp/eKWeUWVNiiBdmUM2qLkBv+VLSJKoWAO+aKmyxxwjjmWhE0FrfA1NQ1a3g+NGMhRbAfQdaYswRAKsul70ISg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.310.0.tgz",
+      "integrity": "sha512-SuB75/xk/gyue24gkriTwO2jFd7YcUGZDClQYuRejgbXSa3CO0lWyawQtfLcSSEBp9izrEVXuFH24K1eAft5nQ==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.272.0.tgz",
-      "integrity": "sha512-pCGvHM7C76VbO/dFerH+Vwf7tGv7j+e+eGrvhQ35mRghCtfIou/WMfTZlD1TNee93crrAQQVZKjtW3dMB3WCzg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.310.0.tgz",
+      "integrity": "sha512-oTPsRy2W4s+dfxbJPW7Km+hHtv/OMsNsVfThAq8DDYKC13qlr1aAyOqGLD+dpBy2aKe7ss517Sy2HcHtHqm7/g==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/service-error-classification": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-middleware": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "tslib": "^2.3.1",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/service-error-classification": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-middleware": "3.310.0",
+        "@aws-sdk/util-retry": "3.310.0",
+        "tslib": "^2.5.0",
         "uuid": "^8.3.2"
       },
       "engines": {
@@ -5152,320 +5466,394 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.272.0.tgz",
-      "integrity": "sha512-VvYPg7LrDIjUOWueSzo2wBzcNG7dw+cmzV6zAKaLxf0RC5jeAP4hE0OzDiiZfDrjNghEzgq/V+0NO+LewqYL9Q==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.310.0.tgz",
+      "integrity": "sha512-+5PFwlYNLvLLIfw0ASAoWV/iIF8Zv6R6QGtyP0CclhRSvNjgbQDVnV0g95MC5qvh+GB/Yjlkt8qAjLSPjHfsrQ==",
       "dependencies": {
-        "@aws-sdk/middleware-signing": "3.272.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/signature-v4": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/middleware-signing": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.272.0.tgz",
-      "integrity": "sha512-kW1uOxgPSwtXPB5rm3QLdWomu42lkYpQL94tM1BjyFOWmBLO2lQhk5a7Dw6HkTozT9a+vxtscLChRa6KZe61Hw==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.310.0.tgz",
+      "integrity": "sha512-RNeeTVWSLTaentUeCgQKZhAl+C6hxtwD78cQWS10UymWpQFwbaxztzKUu4UQS5xA2j6PxwPRRUjqa4jcFjfLsg==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.272.0.tgz",
-      "integrity": "sha512-4LChFK4VAR91X+dupqM8fQqYhFGE0G4Bf9rQlVTgGSbi2KUOmpqXzH0/WKE228nKuEhmH8+Qd2VPSAE2JcyAUA==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.310.0.tgz",
+      "integrity": "sha512-f9mKq+XMdW207Af3hKjdTnpNhdtwqWuvFs/ZyXoOkp/g1MY1O6L23Jy6i52m29LxbT4AuNRG1oKODfXM0vYVjQ==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/signature-v4": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-middleware": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/signature-v4": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-middleware": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.272.0.tgz",
-      "integrity": "sha512-jhwhknnPBGhfXAGV5GXUWfEhDFoP/DN8MPCO2yC5OAxyp6oVJ8lTPLkZYMTW5VL0c0eG44dXpF4Ib01V+PlDrQ==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.310.0.tgz",
+      "integrity": "sha512-010O1PD+UAcZVKRvqEusE1KJqN96wwrf6QsqbRM0ywsKQ21NDweaHvEDlds2VHpgmofxkRLRu/IDrlPkKRQrRg==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.272.0.tgz",
-      "integrity": "sha512-Qy7/0fsDJxY5l0bEk7WKDfqb4Os/sCAgFR2zEvrhDtbkhYPf72ysvg/nRUTncmCbo8tOok4SJii2myk8KMfjjw==",
+      "version": "3.319.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.319.0.tgz",
+      "integrity": "sha512-ytaLx2dlR5AdMSne6FuDCISVg8hjyKj+cHU20b2CRA/E/z+XXrLrssp4JrCgizRKPPUep0psMIa22Zd6osTT5Q==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-endpoints": "3.319.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.272.0.tgz",
-      "integrity": "sha512-YYCIBh9g1EQo7hm2l22HX5Yr9RoPQ2RCvhzKvF1n1e8t1QH4iObQrYUtqHG4khcm64Cft8C5MwZmgzHbya5Z6Q==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.310.0.tgz",
+      "integrity": "sha512-T/Pp6htc6hq/Cq+MLNDSyiwWCMVF6GqbBbXKVlO5L8rdHx4sq9xPdoPveZhGWrxvkanjA6eCwUp6E0riBOSVng==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.272.0.tgz",
-      "integrity": "sha512-VrW9PjhhngeyYp4yGYPe5S0vgZH6NwU3Po9xAgayUeE37Inr7LS1YteFMHdpgsUUeNXnh7d06CXqHo1XjtqOKA==",
+      "version": "3.321.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.321.1.tgz",
+      "integrity": "sha512-DdQBrtFFDNtzphJIN3s93Vf+qd9LHSzH6WTQRrWoXhTDMHDzSI2Cn+c5KWfk89Nggp/n3+OTwUPQeCiBT5EBuw==",
       "dependencies": {
-        "@aws-sdk/abort-controller": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/querystring-builder": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/abort-controller": "3.310.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/querystring-builder": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/property-provider": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.272.0.tgz",
-      "integrity": "sha512-V1pZTaH5eqpAt8O8CzbItHhOtzIfFuWymvwZFkAtwKuaHpnl7jjrTouV482zoq8AD/fF+VVSshwBKYA7bhidIw==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.310.0.tgz",
+      "integrity": "sha512-3lxDb0akV6BBzmFe4nLPaoliQbAifyWJhuvuDOu7e8NzouvpQXs0275w9LePhhcgjKAEVXUIse05ZW2DLbxo/g==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.272.0.tgz",
-      "integrity": "sha512-4JQ54v5Yn08jspNDeHo45CaSn1CvTJqS1Ywgr79eU6jBExtguOWv6LNtwVSBD9X37v88iqaxt8iu1Z3pZZAJeg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.310.0.tgz",
+      "integrity": "sha512-fgZ1aw/irQtnrsR58pS8ThKOWo57Py3xX6giRvwSgZDEcxHfVzuQjy9yPuV++v04fdmdtgpbGf8WfvAAJ11yXQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.272.0.tgz",
-      "integrity": "sha512-ndo++7GkdCj5tBXE6rGcITpSpZS4PfyV38wntGYAlj9liL1omk3bLZRY6uzqqkJpVHqbg2fD7O2qHNItzZgqhw==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.310.0.tgz",
+      "integrity": "sha512-ZHH8GV/80+pWGo7DzsvwvXR5xVxUHXUvPJPFAkhr6nCf78igdoF8gR10ScFoEKbtEapoNTaZlKHPXxpD8aPG7A==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.272.0.tgz",
-      "integrity": "sha512-5oS4/9n6N1LZW9tI3qq/0GnCuWoOXRgcHVB+AJLRBvDbEe+GI+C/xK1tKLsfpDNgsQJHc4IPQoIt4megyZ/1+A==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.310.0.tgz",
+      "integrity": "sha512-YkIznoP6lsiIUHinx++/lbb3tlMURGGqMpo0Pnn32zYzGrJXA6eC3D0as2EcMjo55onTfuLcIiX4qzXes2MYOA==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.272.0.tgz",
-      "integrity": "sha512-REoltM1LK9byyIufLqx9znhSolPcHQgVHIA2S0zu5sdt5qER4OubkLAXuo4MBbisUTmh8VOOvIyUb5ijZCXq1w==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.310.0.tgz",
+      "integrity": "sha512-PuyC7k3qfIKeH2LCnDwbttMOKq3qAx4buvg0yfnJtQOz6t1AR8gsnAq0CjKXXyfkXwNKWTqCpE6lVNUIkXgsMw==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.272.0.tgz",
-      "integrity": "sha512-lzFPohp5sy2XvwFjZIzLVCRpC0i5cwBiaXmFzXYQZJm6FSCszHO4ax+m9yrtlyVFF/2YPWl+/bzNthy4aJtseA==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.310.0.tgz",
+      "integrity": "sha512-N0q9pG0xSjQwc690YQND5bofm+4nfUviQ/Ppgan2kU6aU0WUq8KwgHJBto/YEEI+VlrME30jZJnxtOvcZJc2XA==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/signature-v4": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.272.0.tgz",
-      "integrity": "sha512-pWxnHG1NqJWMwlhJ6NHNiUikOL00DHROmxah6krJPMPq4I3am2KY2Rs/8ouWhnEXKaHAv4EQhSALJ+7Mq5S4/A==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.310.0.tgz",
+      "integrity": "sha512-1M60P1ZBNAjCFv9sYW29OF6okktaeibWyW3lMXqzoHF70lHBZh+838iUchznXUA5FLabfn4jBFWMRxlAXJUY2Q==",
       "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-middleware": "3.272.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "@aws-sdk/util-middleware": "3.310.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/smithy-client": {
-      "version": "3.279.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.279.0.tgz",
-      "integrity": "sha512-ZcYWUQDGAYN6NXRpJuSn46PetrpPCA6TrDVwP9+3pERzTXZ66npXoG2XhHjNrOXy/Ted5A3OxKrM4/zLu9tK3A==",
+      "version": "3.316.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.316.0.tgz",
+      "integrity": "sha512-6YXOKbRnXeS8r8RWzuL6JMBolDYM5Wa4fD/VY6x/wK78i2xErHOvqzHgyyeLI1MMw4uqyd4wRNJNWC9TMPduXw==",
       "dependencies": {
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/middleware-stack": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/token-providers": {
-      "version": "3.281.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.281.0.tgz",
-      "integrity": "sha512-36Vg/F6Edm7qdjcTeNVON+sK2edgHhmhTtAEjWcuUk5AX/Et+Ate/A2N8HD3nxwlAcgidfnBC9SHYJatbhcEnQ==",
+      "version": "3.321.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.321.1.tgz",
+      "integrity": "sha512-I1sXS4qXirSvgvrOIPf+e1D7GvC83DdeyMxHZvuhHgeMCqDAzToS8OLxOX0enN9xZRHWAQYja8xyeGbDL2I0Zw==",
       "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.281.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/client-sso-oidc": "3.321.1",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/types": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.272.0.tgz",
-      "integrity": "sha512-MmmL6vxMGP5Bsi+4wRx4mxYlU/LX6M0noOXrDh/x5FfG7/4ZOar/nDxqDadhJtNM88cuWVHZWY59P54JzkGWmA==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.310.0.tgz",
+      "integrity": "sha512-j8eamQJ7YcIhw7fneUfs8LYl3t01k4uHi4ZDmNRgtbmbmTTG3FZc2MotStZnp3nZB6vLiPF1o5aoJxWVvkzS6A==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/url-parser": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.272.0.tgz",
-      "integrity": "sha512-vX/Tx02PlnQ/Kgtf5TnrNDHPNbY+amLZjW0Z1d9vzAvSZhQ4i9Y18yxoRDIaDTCNVRDjdhV8iuctW+05PB5JtQ==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.310.0.tgz",
+      "integrity": "sha512-mCLnCaSB9rQvAgx33u0DujLvr4d5yEm/W5r789GblwwQnlNXedVu50QRizMLTpltYWyAUoXjJgQnJHmJMaKXhw==",
       "dependencies": {
-        "@aws-sdk/querystring-parser": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/querystring-parser": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-base64": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
+      "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
+      "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
+      "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
+      "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
+      "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.279.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.279.0.tgz",
-      "integrity": "sha512-RnchYRrpapTT5Hu23LOfk6e8RMVq0kUzho6xA6TJj1a4uGxkcRMvgzPipCq1P5uHu0mrkQBg9pGPEVNOUs38/Q==",
+      "version": "3.316.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.316.0.tgz",
+      "integrity": "sha512-6FSqLhYmaihtH2n1s4b2rlLW0ABU8N6VZIfzLfe2ING4PF0MzfaMMhnTFUHVXfKCVGoR8yP6iyFTRCyHGVEL1w==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">= 10.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.279.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.279.0.tgz",
-      "integrity": "sha512-A2NB10xReWC+GSnOivKGZ9rnljIZdEP8WMCQQEnA6DJNI19AUFF/O9QJ9y+cHGLKEms7jH86Y99wShdpzAK+Jw==",
+      "version": "3.316.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.316.0.tgz",
+      "integrity": "sha512-dkYy10hdjPSScXXvnjGpZpnJxllkb6ICHgLMwZ4JczLHhPM12T/4PQ758YN8HS+muiYDGX1Bl2z1jd/bMcewBQ==",
       "dependencies": {
-        "@aws-sdk/config-resolver": "3.272.0",
-        "@aws-sdk/credential-provider-imds": "3.272.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/credential-provider-imds": "3.310.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">= 10.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.272.0.tgz",
-      "integrity": "sha512-c4MPUaJt2G6gGpoiwIOqDfUa98c1J63RpYvf/spQEKOtC/tF5Gfqlxuq8FnAl5lHnrqj1B9ZXLLxFhHtDR0IiQ==",
+      "version": "3.319.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.319.0.tgz",
+      "integrity": "sha512-3I64UMoYA2e2++oOUJXRcFtYLpLylnZFRltWfPo1B3dLlf+MIWat9djT+mMus+hW1ntLsvAIVu1hLVePJC0gvw==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
+      "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-middleware": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.272.0.tgz",
-      "integrity": "sha512-Abw8m30arbwxqmeMMha5J11ESpHUNmCeSqSzE8/C4B8jZQtHY4kq7f+upzcNIQ11lsd+uzBEzNG3+dDRi0XOJQ==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.310.0.tgz",
+      "integrity": "sha512-FTSUKL/eRb9X6uEZClrTe27QFXUNNp7fxYrPndZwk1hlaOP5ix+MIHBcI7pIiiY/JPfOUmPyZOu+HetlFXjWog==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-retry": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.272.0.tgz",
-      "integrity": "sha512-Ngha5414LR4gRHURVKC9ZYXsEJhMkm+SJ+44wlzOhavglfdcKKPUsibz5cKY1jpUV7oKECwaxHWpBB8r6h+hOg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.310.0.tgz",
+      "integrity": "sha512-FwWGhCBLfoivTMUHu1LIn4NjrN9JLJ/aX5aZmbcPIOhZVFJj638j0qDgZXyfvVqBuBZh7M8kGq0Oahy3dp69OA==",
       "dependencies": {
-        "@aws-sdk/service-error-classification": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/service-error-classification": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.272.0.tgz",
-      "integrity": "sha512-Lp5QX5bH6uuwBlIdr7w7OAcAI50ttyskb++yUr9i+SPvj6RI2dsfIBaK4mDg1qUdM5LeUdvIyqwj3XHjFKAAvA==",
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
+      "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.310.0.tgz",
+      "integrity": "sha512-yU/4QnHHuQ5z3vsUqMQVfYLbZGYwpYblPiuZx4Zo9+x0PBkNjYMqctdDcrpoH9Z2xZiDN16AmQGK1tix117ZKw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.272.0.tgz",
-      "integrity": "sha512-ljK+R3l+Q1LIHrcR+Knhk0rmcSkfFadZ8V+crEGpABf/QUQRg7NkZMsoe814tfBO5F7tMxo8wwwSdaVNNHtoRA==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.310.0.tgz",
+      "integrity": "sha512-Ra3pEl+Gn2BpeE7KiDGpi4zj7WJXZA5GXnGo3mjbi9+Y3zrbuhJAbdZO3mO/o7xDgMC6ph4xCTbaSGzU6b6EDg==",
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -5954,6 +6342,18 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/hash-stream-node/node_modules/@aws-sdk/util-utf8": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.254.0.tgz",
+      "integrity": "sha512-14Kso/eIt5/qfIBmhEL9L1IfyUqswjSTqO2mY7KOzUZ9SZbwn3rpxmtkhmATkRjD7XIlLKaxBkI7tU9Zjzj8Kw==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/invalid-dependency": {
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.226.0.tgz",
@@ -5989,6 +6389,18 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.272.0.tgz",
       "integrity": "sha512-MmmL6vxMGP5Bsi+4wRx4mxYlU/LX6M0noOXrDh/x5FfG7/4ZOar/nDxqDadhJtNM88cuWVHZWY59P54JzkGWmA==",
       "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/md5-js/node_modules/@aws-sdk/util-utf8": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.254.0.tgz",
+      "integrity": "sha512-14Kso/eIt5/qfIBmhEL9L1IfyUqswjSTqO2mY7KOzUZ9SZbwn3rpxmtkhmATkRjD7XIlLKaxBkI7tU9Zjzj8Kw==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -6134,6 +6546,18 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.272.0.tgz",
       "integrity": "sha512-MmmL6vxMGP5Bsi+4wRx4mxYlU/LX6M0noOXrDh/x5FfG7/4ZOar/nDxqDadhJtNM88cuWVHZWY59P54JzkGWmA==",
       "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/util-utf8": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.254.0.tgz",
+      "integrity": "sha512-14Kso/eIt5/qfIBmhEL9L1IfyUqswjSTqO2mY7KOzUZ9SZbwn3rpxmtkhmATkRjD7XIlLKaxBkI7tU9Zjzj8Kw==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -6534,6 +6958,18 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/util-utf8": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.254.0.tgz",
+      "integrity": "sha512-14Kso/eIt5/qfIBmhEL9L1IfyUqswjSTqO2mY7KOzUZ9SZbwn3rpxmtkhmATkRjD7XIlLKaxBkI7tU9Zjzj8Kw==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/smithy-client": {
       "version": "3.234.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.234.0.tgz",
@@ -6736,138 +7172,229 @@
       }
     },
     "node_modules/@aws-sdk/util-stream-browser": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.272.0.tgz",
-      "integrity": "sha512-vD514YffKxBjV/erjUNgkXcb/mzXAz3uk/KUFMXsodo3cA4Z8WxL4P0p1O09FVuJlNa0gZ8mhFPNzNOekh31GA==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.310.0.tgz",
+      "integrity": "sha512-bysXZHwFwvbqOTCScCdCnoLk1K3GCo0HRIYEZuL7O7MHrQmfaYRXcaft/p22+GUv9VeFXS/eJJZ5r4u32az94w==",
       "dependencies": {
-        "@aws-sdk/fetch-http-handler": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/fetch-http-handler": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.272.0.tgz",
-      "integrity": "sha512-1Qhm9e0RbS1Xf4CZqUbQyUMkDLd7GrsRXWIvm9b86/vgeV8/WnjO3CMue9D51nYgcyQORhYXv6uVjAYCWbUExA==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.310.0.tgz",
+      "integrity": "sha512-Bi9vIwzdkw1zMcvi/zGzlWS9KfIEnAq4NNhsnCxbQ4OoIRU9wvU+WGZdBBhxg0ZxZmpp1j1aZhU53lLjA07MHw==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/querystring-builder": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/querystring-builder": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
+      "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.272.0.tgz",
-      "integrity": "sha512-4JQ54v5Yn08jspNDeHo45CaSn1CvTJqS1Ywgr79eU6jBExtguOWv6LNtwVSBD9X37v88iqaxt8iu1Z3pZZAJeg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.310.0.tgz",
+      "integrity": "sha512-fgZ1aw/irQtnrsR58pS8ThKOWo57Py3xX6giRvwSgZDEcxHfVzuQjy9yPuV++v04fdmdtgpbGf8WfvAAJ11yXQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.272.0.tgz",
-      "integrity": "sha512-ndo++7GkdCj5tBXE6rGcITpSpZS4PfyV38wntGYAlj9liL1omk3bLZRY6uzqqkJpVHqbg2fD7O2qHNItzZgqhw==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.310.0.tgz",
+      "integrity": "sha512-ZHH8GV/80+pWGo7DzsvwvXR5xVxUHXUvPJPFAkhr6nCf78igdoF8gR10ScFoEKbtEapoNTaZlKHPXxpD8aPG7A==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/types": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.272.0.tgz",
-      "integrity": "sha512-MmmL6vxMGP5Bsi+4wRx4mxYlU/LX6M0noOXrDh/x5FfG7/4ZOar/nDxqDadhJtNM88cuWVHZWY59P54JzkGWmA==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.310.0.tgz",
+      "integrity": "sha512-j8eamQJ7YcIhw7fneUfs8LYl3t01k4uHi4ZDmNRgtbmbmTTG3FZc2MotStZnp3nZB6vLiPF1o5aoJxWVvkzS6A==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/util-base64": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
+      "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
+      "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
+      "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
+      "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
+      "dependencies": {
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-stream-node": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.272.0.tgz",
-      "integrity": "sha512-s7dGeM1ImzihqBKgrpaeZokLnPUk3H4Et5oiM+t+TpRxotXTecJPyuD0p76HRgO8KSXfVT5Nxw/FoHXqj1fiMg==",
+      "version": "3.321.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.321.1.tgz",
+      "integrity": "sha512-jvfff1zeA8q16hQWSC0BGwcHJPCwoh+bwiuAjihfl9q1tFLYuqaTzJzzkL1bntUsbW+y/ac5DO7fWcYPq0jWkw==",
       "dependencies": {
-        "@aws-sdk/node-http-handler": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/node-http-handler": "3.321.1",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/abort-controller": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.272.0.tgz",
-      "integrity": "sha512-s2TV3phapcTwZNr4qLxbfuQuE9ZMP4RoJdkvRRCkKdm6jslsWLJf2Zlcxti/23hOlINUMYv2iXE2pftIgWGdpg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.310.0.tgz",
+      "integrity": "sha512-v1zrRQxDLA1MdPim159Vx/CPHqsB4uybSxRi1CnfHO5ZjHryx3a5htW2gdGAykVCul40+yJXvfpufMrELVxH+g==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
+      "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
+      "dependencies": {
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.272.0.tgz",
-      "integrity": "sha512-VrW9PjhhngeyYp4yGYPe5S0vgZH6NwU3Po9xAgayUeE37Inr7LS1YteFMHdpgsUUeNXnh7d06CXqHo1XjtqOKA==",
+      "version": "3.321.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.321.1.tgz",
+      "integrity": "sha512-DdQBrtFFDNtzphJIN3s93Vf+qd9LHSzH6WTQRrWoXhTDMHDzSI2Cn+c5KWfk89Nggp/n3+OTwUPQeCiBT5EBuw==",
       "dependencies": {
-        "@aws-sdk/abort-controller": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/querystring-builder": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/abort-controller": "3.310.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/querystring-builder": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.272.0.tgz",
-      "integrity": "sha512-4JQ54v5Yn08jspNDeHo45CaSn1CvTJqS1Ywgr79eU6jBExtguOWv6LNtwVSBD9X37v88iqaxt8iu1Z3pZZAJeg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.310.0.tgz",
+      "integrity": "sha512-fgZ1aw/irQtnrsR58pS8ThKOWo57Py3xX6giRvwSgZDEcxHfVzuQjy9yPuV++v04fdmdtgpbGf8WfvAAJ11yXQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.272.0.tgz",
-      "integrity": "sha512-ndo++7GkdCj5tBXE6rGcITpSpZS4PfyV38wntGYAlj9liL1omk3bLZRY6uzqqkJpVHqbg2fD7O2qHNItzZgqhw==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.310.0.tgz",
+      "integrity": "sha512-ZHH8GV/80+pWGo7DzsvwvXR5xVxUHXUvPJPFAkhr6nCf78igdoF8gR10ScFoEKbtEapoNTaZlKHPXxpD8aPG7A==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/types": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.272.0.tgz",
-      "integrity": "sha512-MmmL6vxMGP5Bsi+4wRx4mxYlU/LX6M0noOXrDh/x5FfG7/4ZOar/nDxqDadhJtNM88cuWVHZWY59P54JzkGWmA==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.310.0.tgz",
+      "integrity": "sha512-j8eamQJ7YcIhw7fneUfs8LYl3t01k4uHi4ZDmNRgtbmbmTTG3FZc2MotStZnp3nZB6vLiPF1o5aoJxWVvkzS6A==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
+      "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
+      "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
+      "dependencies": {
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -6916,12 +7443,12 @@
       }
     },
     "node_modules/@aws-sdk/util-utf8": {
-      "version": "3.254.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.254.0.tgz",
-      "integrity": "sha512-14Kso/eIt5/qfIBmhEL9L1IfyUqswjSTqO2mY7KOzUZ9SZbwn3rpxmtkhmATkRjD7XIlLKaxBkI7tU9Zjzj8Kw==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.310.0.tgz",
+      "integrity": "sha512-DnLfFT8uCO22uOJc0pt0DsSNau1GTisngBCDw8jQuWT5CqogMJu4b/uXmwEqfj8B3GX6Xsz8zOd6JpRlPftQoA==",
       "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -6947,37 +7474,60 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/util-waiter": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.272.0.tgz",
-      "integrity": "sha512-N25/XsJ2wkPh1EgkFyb/GRgfHDityScfD49Hk1AwJWpfetzgkcEtWdeW4IuPymXlSKhrm5L+SBw49USxo9kBag==",
+    "node_modules/@aws-sdk/util-utf8/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
+      "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
       "dependencies": {
-        "@aws-sdk/abort-controller": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8/node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
+      "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-waiter": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.310.0.tgz",
+      "integrity": "sha512-AV5j3guH/Y4REu+Qh3eXQU9igljHuU4XjX2sADAgf54C0kkhcCCkkiuzk3IsX089nyJCqIcj5idbjdvpnH88Vw==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-waiter/node_modules/@aws-sdk/abort-controller": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.272.0.tgz",
-      "integrity": "sha512-s2TV3phapcTwZNr4qLxbfuQuE9ZMP4RoJdkvRRCkKdm6jslsWLJf2Zlcxti/23hOlINUMYv2iXE2pftIgWGdpg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.310.0.tgz",
+      "integrity": "sha512-v1zrRQxDLA1MdPim159Vx/CPHqsB4uybSxRi1CnfHO5ZjHryx3a5htW2gdGAykVCul40+yJXvfpufMrELVxH+g==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-waiter/node_modules/@aws-sdk/types": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.272.0.tgz",
-      "integrity": "sha512-MmmL6vxMGP5Bsi+4wRx4mxYlU/LX6M0noOXrDh/x5FfG7/4ZOar/nDxqDadhJtNM88cuWVHZWY59P54JzkGWmA==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.310.0.tgz",
+      "integrity": "sha512-j8eamQJ7YcIhw7fneUfs8LYl3t01k4uHi4ZDmNRgtbmbmTTG3FZc2MotStZnp3nZB6vLiPF1o5aoJxWVvkzS6A==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -7003,17 +7553,18 @@
       }
     },
     "node_modules/@awsui/component-toolkit": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@awsui/component-toolkit/-/component-toolkit-1.0.0-beta.4.tgz",
-      "integrity": "sha512-6rxgDemVPS2OorC48fGjcnVBEdAqBRoWgrTCh1mClNfuHwioHxyICBUqxFCUxsIN8HHa/iAG9VFA+e4uoGN24g==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@awsui/component-toolkit/-/component-toolkit-1.0.0-beta.5.tgz",
+      "integrity": "sha512-sa45TYaMkl95eBl6MsRLJwJFKLxOfKrfi5ki+eSY+Z1AKkJLRAvMkbaw7g/BaXdsrCmgjElmoQshUMPzfDtMzQ==",
       "dependencies": {
-        "@juggle/resize-observer": "^3.3.1"
+        "@juggle/resize-observer": "^3.3.1",
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@awsui/components-react": {
-      "version": "3.0.820",
-      "resolved": "https://registry.npmjs.org/@awsui/components-react/-/components-react-3.0.820.tgz",
-      "integrity": "sha512-MRiXcRuJcuqixQfDr/ctFGPchdtel2zcHCyeL/SZFJIeVJ0yCFSsnQdax6GKZ70qNWgqcXtg+k/qm104PQb+TA==",
+      "version": "3.0.821",
+      "resolved": "https://registry.npmjs.org/@awsui/components-react/-/components-react-3.0.821.tgz",
+      "integrity": "sha512-IZcsc1FEBZS/nz6ob24Xg6GB9M5qB9ygexu2USODtHgXsFEuzOixHBTABJMP9rwupTOezF9ZuL4EGQZg5eb/zQ==",
       "dependencies": {
         "@awsui/collection-hooks": "^1.0.0",
         "@awsui/component-toolkit": "^1.0.0-beta",
@@ -8839,17 +9390,18 @@
       }
     },
     "node_modules/@cloudscape-design/component-toolkit": {
-      "version": "1.0.0-beta.13",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/component-toolkit/-/component-toolkit-1.0.0-beta.13.tgz",
-      "integrity": "sha512-Sl4TjLZnLxeLBB63NZlIk3J1M4wFUnRtljI4PGfFVj+VgUia/DseBkgNguo7xnYIVF21wVaAHKsmrxPxfxDTaQ==",
+      "version": "1.0.0-beta.14",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/component-toolkit/-/component-toolkit-1.0.0-beta.14.tgz",
+      "integrity": "sha512-FUncISDyZJMOuuFDFzzXUdrew+deTpF7oJeox34b9Xm69L7fJYQV5mOkKckFW5/lnE52n3pENfU5hLb+ic+baw==",
       "dependencies": {
-        "@juggle/resize-observer": "^3.3.1"
+        "@juggle/resize-observer": "^3.3.1",
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@cloudscape-design/components": {
-      "version": "3.0.275",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/components/-/components-3.0.275.tgz",
-      "integrity": "sha512-6bXCdXmvZcbCGlQYj2xaIDpmJg0JW/uF6YCYSLChMcZZ7QoxrW61eb2EiAy8kv6Cau83/HosJAc9+skZolNMbQ==",
+      "version": "3.0.276",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/components/-/components-3.0.276.tgz",
+      "integrity": "sha512-rC+ZFAvCAaHdPxCBkg5ydprndEG6lGdTMIYawHpeivpnPIU9muUlhh/Psp5CTdSyY992r6Al4NveSuIwtKr9Yw==",
       "dependencies": {
         "@cloudscape-design/collection-hooks": "^1.0.0",
         "@cloudscape-design/component-toolkit": "^1.0.0-beta",
@@ -9377,15 +9929,15 @@
       }
     },
     "node_modules/@iot-app-kit/components": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@iot-app-kit/components/-/components-5.5.1.tgz",
-      "integrity": "sha512-UpAj7PJeni6+5VDvw5396cugCI+jepO3+QhMsJkmPhpAj1nZEEFGrg/kShUh4DRls6bpgkxtdwn15Ooawt9akQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@iot-app-kit/components/-/components-5.7.0.tgz",
+      "integrity": "sha512-YsfAIzSigIw7DNmj7IfEZsjGzdZkhLCQdymAtDHlXQL09R8B+gFmz7yf1UY6nnuV1w61uRcKFXGYiImj0EA+Bw==",
       "dependencies": {
         "@awsui/collection-hooks": "^1.0.0",
         "@awsui/components-react": "^3.0.0",
         "@awsui/design-tokens": "^3.0.0",
-        "@iot-app-kit/core": "5.5.1",
-        "@iot-app-kit/related-table": "5.5.1",
+        "@iot-app-kit/core": "5.7.0",
+        "@iot-app-kit/related-table": "5.7.0",
         "@stencil/core": "^2.7.0",
         "@synchro-charts/core": "7.2.0",
         "styled-components": "^5.3.9"
@@ -9396,12 +9948,12 @@
       }
     },
     "node_modules/@iot-app-kit/core": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@iot-app-kit/core/-/core-5.5.1.tgz",
-      "integrity": "sha512-9pDC4bbf1H+tkXlCl2yN9cAHXPoOkN/ocxfkv9VDKwrqfPyy2dM4g1CDHhELGRgmCVTs9RFCgNPVR8skX2yOvQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@iot-app-kit/core/-/core-5.7.0.tgz",
+      "integrity": "sha512-aqUbqNsQk+BnS8mdmCqD/68Q9OUKZhdEmFI3F0+HSPZjIzOs/Qe5m6e/OF+K/ornWtDtj6fexKuZsTlj8FoNjA==",
       "dependencies": {
-        "@aws-sdk/client-iotsitewise": "3.281.0",
-        "d3-array": "^3.2.2",
+        "@aws-sdk/client-iotsitewise": "3.319.0",
+        "d3-array": "^3.2.3",
         "intervals-fn": "^3.0.3",
         "parse-duration": "^1.0.3",
         "redux": "^4.2.1",
@@ -9410,12 +9962,12 @@
       }
     },
     "node_modules/@iot-app-kit/core-util": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@iot-app-kit/core-util/-/core-util-5.5.1.tgz",
-      "integrity": "sha512-iP9tFc0lQZbZ6QHDnZUjcdY8BLo/E2ab8uaul9nL2zFh7Noq2hAJX/HD8LG19YVn8AAQoAZkHkerq0JQ1hiGVQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@iot-app-kit/core-util/-/core-util-5.7.0.tgz",
+      "integrity": "sha512-BmKuUa+c5p33w9DLMuiwKf/p0b5rvN7ihuTEcWgmokal7AMeM+opXRVTS6TFqXj0mnJAMmnBr+VC9b8yEvSwsw==",
       "dependencies": {
-        "@aws-sdk/client-iot-events": "3.281.0",
-        "@aws-sdk/client-iotsitewise": "3.281.0"
+        "@aws-sdk/client-iot-events": "3.319.0",
+        "@aws-sdk/client-iotsitewise": "3.319.0"
       }
     },
     "node_modules/@iot-app-kit/core/node_modules/uuid": {
@@ -9427,21 +9979,21 @@
       }
     },
     "node_modules/@iot-app-kit/react-components": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@iot-app-kit/react-components/-/react-components-5.5.1.tgz",
-      "integrity": "sha512-fkZkCjW5yvETAVDYdBniXaWjP2zngxKMlnYpVbZFO17MAxr8Qr4wHhjdWFxA28DxM42+aAsddqtgUfrVQCiaeQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@iot-app-kit/react-components/-/react-components-5.7.0.tgz",
+      "integrity": "sha512-sMvBhgu9o2bABWrdxf3m01mr3lmSKrRqbHOX1KbStlVBMfM/I4Vo8OITuOurmrUpUY8IhtgAk1Yxnia18QUKhg==",
       "dependencies": {
         "@cloudscape-design/collection-hooks": "^1.0.19",
         "@cloudscape-design/components": "^3.0.244",
         "@cloudscape-design/design-tokens": "^3.0.9",
-        "@iot-app-kit/charts": "^1.8.1",
-        "@iot-app-kit/charts-core": "^1.8.1",
-        "@iot-app-kit/components": "5.5.1",
-        "@iot-app-kit/core": "5.5.1",
-        "@iot-app-kit/core-util": "5.5.1",
-        "@iot-app-kit/source-iottwinmaker": "5.5.1",
+        "@iot-app-kit/charts": "^1.8.4",
+        "@iot-app-kit/charts-core": "^1.8.4",
+        "@iot-app-kit/components": "5.7.0",
+        "@iot-app-kit/core": "5.7.0",
+        "@iot-app-kit/core-util": "5.7.0",
+        "@iot-app-kit/source-iottwinmaker": "5.7.0",
         "color": "^4.2.3",
-        "d3-array": "^3.2.2",
+        "d3-array": "^3.2.3",
         "d3-shape": "^3.2.0",
         "dompurify": "2.3.4",
         "lodash.omitby": "^4.6.0",
@@ -9464,9 +10016,9 @@
       }
     },
     "node_modules/@iot-app-kit/related-table": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@iot-app-kit/related-table/-/related-table-5.5.1.tgz",
-      "integrity": "sha512-E7hIQNUNTflTTRF83guOTasOBa2gyAIkOIUtv/6FseOFOcWDSf9Xykv/jHOQeH5JgIt0BJtwvkIA3kUAq+Xwdw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@iot-app-kit/related-table/-/related-table-5.7.0.tgz",
+      "integrity": "sha512-GkaJHWopb1etDOxkydcjey0yyb2y25IHnyisaeY+q6qxFHTaL+FK315nQYnEQhBpnkdlEtwWUhITyq/+Y1sBNQ==",
       "dependencies": {
         "uuid": "^9.0.0"
       },
@@ -9488,19 +10040,19 @@
       }
     },
     "node_modules/@iot-app-kit/scene-composer": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@iot-app-kit/scene-composer/-/scene-composer-5.5.1.tgz",
-      "integrity": "sha512-KYZ8Ouiw/ZKXnLMFU8t0qfHt8onspXkUmmalGAqKZJtX7+NtzxYe32B9GlRldrItxLOlrAXJRbIqnkalvkAQkw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@iot-app-kit/scene-composer/-/scene-composer-5.7.0.tgz",
+      "integrity": "sha512-oRFdkcfVpfATr9OjzipvIRiRj1n4f81ArFeB9y6RwSMNS6/Y30/Z+dtCni22B3+YlaCoUZheJCoQfWqJxxBHNA==",
       "dependencies": {
         "@awsui/collection-hooks": "^1.0.0",
         "@awsui/components-react": "^3.0.0",
         "@awsui/design-tokens": "^3.0.0",
         "@awsui/global-styles": "^1.0.12",
         "@formatjs/ts-transformer": "3.9.11",
-        "@iot-app-kit/core": "5.5.1",
-        "@iot-app-kit/related-table": "5.5.1",
-        "@matterport/r3f": "^0.1.0",
-        "@matterport/webcomponent": "^0.1.2",
+        "@iot-app-kit/core": "5.7.0",
+        "@iot-app-kit/related-table": "5.7.0",
+        "@matterport/r3f": "^0.2.1",
+        "@matterport/webcomponent": "^0.1.21",
         "@react-three/drei": "9.56.27",
         "@react-three/fiber": "^8.11.5",
         "@react-three/postprocessing": "2.6.2",
@@ -9517,8 +10069,8 @@
         "postprocessing": "6.28.5",
         "react-color": "^2.19.3",
         "react-dnd": "^16.0.1",
-        "react-dnd-html5-backend": "^15.1.3",
-        "react-markdown": "^8.0.5",
+        "react-dnd-html5-backend": "^16.0.1",
+        "react-markdown": "^8.0.7",
         "rehype-sanitize": "^5.0.1",
         "stats.js": "^0.17.0",
         "string-to-arraybuffer": "1.0.2",
@@ -9526,7 +10078,7 @@
         "three": "^0.139.2",
         "three-mesh-bvh": "0.5.15",
         "three-stdlib": "2.17.3",
-        "ts-custom-error": "^3.2.0",
+        "ts-custom-error": "^3.3.1",
         "tslib": "^2.3.1",
         "typescript": "^4.5",
         "zundo": "1.1.0",
@@ -9560,18 +10112,18 @@
       }
     },
     "node_modules/@iot-app-kit/source-iottwinmaker": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@iot-app-kit/source-iottwinmaker/-/source-iottwinmaker-5.5.1.tgz",
-      "integrity": "sha512-ZTMOPKS7Pu3Rnon6V3qmjsACQ6T40iwRyVam2Pq+uV6UrtmRRWixTHLorJLmaAmfEyVc+lTO6Pv34bSJ+q7eLg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@iot-app-kit/source-iottwinmaker/-/source-iottwinmaker-5.7.0.tgz",
+      "integrity": "sha512-2OaNPEFBHH4ZzkpX1KFN4nxd00XNTCHzrlZeyvcqP9CL38dDL1E1VS8dw+zjrH3ZXhqioi436c4ijQ3aXNzU+g==",
       "dependencies": {
-        "@aws-sdk/client-iotsitewise": "3.281.0",
+        "@aws-sdk/client-iotsitewise": "3.319.0",
         "@aws-sdk/client-iottwinmaker": "3.297.0",
         "@aws-sdk/client-kinesis-video": "3.281.0",
-        "@aws-sdk/client-kinesis-video-archived-media": "3.281.0",
+        "@aws-sdk/client-kinesis-video-archived-media": "3.321.1",
         "@aws-sdk/client-s3": "3.281.0",
-        "@aws-sdk/client-secrets-manager": "3.281.0",
+        "@aws-sdk/client-secrets-manager": "3.321.1",
         "@aws-sdk/url-parser": "3.289.0",
-        "@iot-app-kit/core": "5.5.1",
+        "@iot-app-kit/core": "5.7.0",
         "lodash": "^4.17.21",
         "rxjs": "^7.8.0"
       }
@@ -10765,11 +11317,11 @@
       }
     },
     "node_modules/@matterport/r3f": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@matterport/r3f/-/r3f-0.1.0.tgz",
-      "integrity": "sha512-/aW9qngBygBLq1QpUUI0PFrEbeQur5kFGf591lr3VN1mDHtmQgVSvTOJAri91gtqzggrXYlq4mwMw4mzjaXAgA==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@matterport/r3f/-/r3f-0.2.3.tgz",
+      "integrity": "sha512-HMz0msMyCkBPZ+uUY2HJ3Rm0e62ll2uCgOYH7zwWrWaQI3hPtJfJr5cfBsNKwh9vcHgj+Q8c2AuTh4eJnp8M2A==",
       "peerDependencies": {
-        "@matterport/webcomponent": ">=0.1.2",
+        "@matterport/webcomponent": ">=0.1.7",
         "@react-three/fiber": "^8.9.2",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
@@ -13439,9 +13991,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.387",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.387.tgz",
-      "integrity": "sha512-tutLf+alr1/0YqJwKPdstVvDLmxmLb5xNyDLNS0RZmenHcEYk9qKfpKDCVZEKJ00JVbnayJm1MZAbYhYDFpcOw==",
+      "version": "1.4.388",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.388.tgz",
+      "integrity": "sha512-xZ0y4zjWZgp65okzwwt00f2rYibkFPHUv9qBz+Vzn8cB9UXIo9Zc6Dw81LJYhhNt0G/vR1OJEfStZ49NKl0YxQ==",
       "dev": true
     },
     "node_modules/emojis-list": {
@@ -16809,31 +17361,11 @@
       }
     },
     "node_modules/react-dnd-html5-backend": {
-      "version": "15.1.3",
-      "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-15.1.3.tgz",
-      "integrity": "sha512-HH/8nOEmrrcRGHMqJR91FOwhnLlx5SRLXmsQwZT3IPcBjx88WT+0pWC5A4tDOYDdoooh9k+KMPvWfxooR5TcOA==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-16.0.1.tgz",
+      "integrity": "sha512-Wu3dw5aDJmOGw8WjH1I1/yTH+vlXEL4vmjk5p+MHxP8HuHJS1lAGeIdG/hze1AvNeXWo/JgULV87LyQOr+r5jw==",
       "dependencies": {
-        "dnd-core": "15.1.2"
-      }
-    },
-    "node_modules/react-dnd-html5-backend/node_modules/@react-dnd/asap": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@react-dnd/asap/-/asap-4.0.1.tgz",
-      "integrity": "sha512-kLy0PJDDwvwwTXxqTFNAAllPHD73AycE9ypWeln/IguoGBEbvFcPDbCV03G52bEcC5E+YgupBE0VzHGdC8SIXg=="
-    },
-    "node_modules/react-dnd-html5-backend/node_modules/@react-dnd/invariant": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@react-dnd/invariant/-/invariant-3.0.1.tgz",
-      "integrity": "sha512-blqduwV86oiKw2Gr44wbe3pj3Z/OsXirc7ybCv9F/pLAR+Aih8F3rjeJzK0ANgtYKv5lCpkGVoZAeKitKDaD/g=="
-    },
-    "node_modules/react-dnd-html5-backend/node_modules/dnd-core": {
-      "version": "15.1.2",
-      "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-15.1.2.tgz",
-      "integrity": "sha512-EOec1LyJUuGRFg0LDa55rSRAUe97uNVKVkUo8iyvzQlcECYTuPblVQfRWXWj1OyPseFIeebWpNmKFy0h6BcF1A==",
-      "dependencies": {
-        "@react-dnd/asap": "4.0.1",
-        "@react-dnd/invariant": "3.0.1",
-        "redux": "^4.1.2"
+        "dnd-core": "^16.0.1"
       }
     },
     "node_modules/react-dom": {
@@ -19423,45 +19955,45 @@
       }
     },
     "@aws-sdk/client-iot-events": {
-      "version": "3.281.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-iot-events/-/client-iot-events-3.281.0.tgz",
-      "integrity": "sha512-uRX8rE6zOVXxa0UOVm/KzfUhopzwsYBL2A/62f9NaE4XEV7vwLm6Xpw6HGDUdmmV3Wjc/qPOl9DM2L8pWanEiQ==",
+      "version": "3.319.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-iot-events/-/client-iot-events-3.319.0.tgz",
+      "integrity": "sha512-kwIN83SuGJ55zzvQEzFJBCmbfJOvf24a4pBTBFXcKNyxn3akQXypY9rvTrnDDBuN1MenO/OJcuA9/E1WOLfjpA==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.281.0",
-        "@aws-sdk/config-resolver": "3.272.0",
-        "@aws-sdk/credential-provider-node": "3.281.0",
-        "@aws-sdk/fetch-http-handler": "3.272.0",
-        "@aws-sdk/hash-node": "3.272.0",
-        "@aws-sdk/invalid-dependency": "3.272.0",
-        "@aws-sdk/middleware-content-length": "3.272.0",
-        "@aws-sdk/middleware-endpoint": "3.272.0",
-        "@aws-sdk/middleware-host-header": "3.278.0",
-        "@aws-sdk/middleware-logger": "3.272.0",
-        "@aws-sdk/middleware-recursion-detection": "3.272.0",
-        "@aws-sdk/middleware-retry": "3.272.0",
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/middleware-signing": "3.272.0",
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/middleware-user-agent": "3.272.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/node-http-handler": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/smithy-client": "3.279.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-        "@aws-sdk/util-defaults-mode-node": "3.279.0",
-        "@aws-sdk/util-endpoints": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "@aws-sdk/util-user-agent-browser": "3.272.0",
-        "@aws-sdk/util-user-agent-node": "3.272.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/client-sts": "3.319.0",
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/credential-provider-node": "3.319.0",
+        "@aws-sdk/fetch-http-handler": "3.310.0",
+        "@aws-sdk/hash-node": "3.310.0",
+        "@aws-sdk/invalid-dependency": "3.310.0",
+        "@aws-sdk/middleware-content-length": "3.310.0",
+        "@aws-sdk/middleware-endpoint": "3.310.0",
+        "@aws-sdk/middleware-host-header": "3.310.0",
+        "@aws-sdk/middleware-logger": "3.310.0",
+        "@aws-sdk/middleware-recursion-detection": "3.310.0",
+        "@aws-sdk/middleware-retry": "3.310.0",
+        "@aws-sdk/middleware-serde": "3.310.0",
+        "@aws-sdk/middleware-signing": "3.310.0",
+        "@aws-sdk/middleware-stack": "3.310.0",
+        "@aws-sdk/middleware-user-agent": "3.319.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/node-http-handler": "3.310.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/smithy-client": "3.316.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+        "@aws-sdk/util-defaults-mode-node": "3.316.0",
+        "@aws-sdk/util-endpoints": "3.319.0",
+        "@aws-sdk/util-retry": "3.310.0",
+        "@aws-sdk/util-user-agent-browser": "3.310.0",
+        "@aws-sdk/util-user-agent-node": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "dependencies": {
         "@aws-crypto/ie11-detection": {
@@ -19551,585 +20083,645 @@
           }
         },
         "@aws-sdk/abort-controller": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.272.0.tgz",
-          "integrity": "sha512-s2TV3phapcTwZNr4qLxbfuQuE9ZMP4RoJdkvRRCkKdm6jslsWLJf2Zlcxti/23hOlINUMYv2iXE2pftIgWGdpg==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.310.0.tgz",
+          "integrity": "sha512-v1zrRQxDLA1MdPim159Vx/CPHqsB4uybSxRi1CnfHO5ZjHryx3a5htW2gdGAykVCul40+yJXvfpufMrELVxH+g==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/client-sso": {
-          "version": "3.281.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.281.0.tgz",
-          "integrity": "sha512-3RvO5zClQhu37w9VMLoHPGk58S3y8Spb7XX8rW51bm5TUglYQskQ0X2VLEUW/7ZGx/peokHws9Z9+w5yGq5sdA==",
+          "version": "3.319.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.319.0.tgz",
+          "integrity": "sha512-g46KgAjRiYBS8Oi85DPwSAQpt+Hgmw/YFgGVwZqMfTL70KNJwLFKRa5D9UocQd7t7OjPRdKF7g0Gp5peyAK9dw==",
           "requires": {
             "@aws-crypto/sha256-browser": "3.0.0",
             "@aws-crypto/sha256-js": "3.0.0",
-            "@aws-sdk/config-resolver": "3.272.0",
-            "@aws-sdk/fetch-http-handler": "3.272.0",
-            "@aws-sdk/hash-node": "3.272.0",
-            "@aws-sdk/invalid-dependency": "3.272.0",
-            "@aws-sdk/middleware-content-length": "3.272.0",
-            "@aws-sdk/middleware-endpoint": "3.272.0",
-            "@aws-sdk/middleware-host-header": "3.278.0",
-            "@aws-sdk/middleware-logger": "3.272.0",
-            "@aws-sdk/middleware-recursion-detection": "3.272.0",
-            "@aws-sdk/middleware-retry": "3.272.0",
-            "@aws-sdk/middleware-serde": "3.272.0",
-            "@aws-sdk/middleware-stack": "3.272.0",
-            "@aws-sdk/middleware-user-agent": "3.272.0",
-            "@aws-sdk/node-config-provider": "3.272.0",
-            "@aws-sdk/node-http-handler": "3.272.0",
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/smithy-client": "3.279.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/url-parser": "3.272.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-            "@aws-sdk/util-defaults-mode-node": "3.279.0",
-            "@aws-sdk/util-endpoints": "3.272.0",
-            "@aws-sdk/util-retry": "3.272.0",
-            "@aws-sdk/util-user-agent-browser": "3.272.0",
-            "@aws-sdk/util-user-agent-node": "3.272.0",
-            "@aws-sdk/util-utf8": "3.254.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/config-resolver": "3.310.0",
+            "@aws-sdk/fetch-http-handler": "3.310.0",
+            "@aws-sdk/hash-node": "3.310.0",
+            "@aws-sdk/invalid-dependency": "3.310.0",
+            "@aws-sdk/middleware-content-length": "3.310.0",
+            "@aws-sdk/middleware-endpoint": "3.310.0",
+            "@aws-sdk/middleware-host-header": "3.310.0",
+            "@aws-sdk/middleware-logger": "3.310.0",
+            "@aws-sdk/middleware-recursion-detection": "3.310.0",
+            "@aws-sdk/middleware-retry": "3.310.0",
+            "@aws-sdk/middleware-serde": "3.310.0",
+            "@aws-sdk/middleware-stack": "3.310.0",
+            "@aws-sdk/middleware-user-agent": "3.319.0",
+            "@aws-sdk/node-config-provider": "3.310.0",
+            "@aws-sdk/node-http-handler": "3.310.0",
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/smithy-client": "3.316.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/url-parser": "3.310.0",
+            "@aws-sdk/util-base64": "3.310.0",
+            "@aws-sdk/util-body-length-browser": "3.310.0",
+            "@aws-sdk/util-body-length-node": "3.310.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+            "@aws-sdk/util-defaults-mode-node": "3.316.0",
+            "@aws-sdk/util-endpoints": "3.319.0",
+            "@aws-sdk/util-retry": "3.310.0",
+            "@aws-sdk/util-user-agent-browser": "3.310.0",
+            "@aws-sdk/util-user-agent-node": "3.310.0",
+            "@aws-sdk/util-utf8": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/client-sso-oidc": {
-          "version": "3.281.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.281.0.tgz",
-          "integrity": "sha512-P6zf9pDuxApVoCYStAg7L8BU9AcWI8PxfLSX4r2WnmcQropxzPJ3op1j9nvbwwBDMFWephijVY4AVp8MqPcPyg==",
+          "version": "3.319.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.319.0.tgz",
+          "integrity": "sha512-GJBgT/tephRZY3oTbDBMv+G9taoqKUIvGPn+7shmzz2P1SerutsRSfKfDXV+VptPNRoGmjjCLPmWjMFYbFKILQ==",
           "requires": {
             "@aws-crypto/sha256-browser": "3.0.0",
             "@aws-crypto/sha256-js": "3.0.0",
-            "@aws-sdk/config-resolver": "3.272.0",
-            "@aws-sdk/fetch-http-handler": "3.272.0",
-            "@aws-sdk/hash-node": "3.272.0",
-            "@aws-sdk/invalid-dependency": "3.272.0",
-            "@aws-sdk/middleware-content-length": "3.272.0",
-            "@aws-sdk/middleware-endpoint": "3.272.0",
-            "@aws-sdk/middleware-host-header": "3.278.0",
-            "@aws-sdk/middleware-logger": "3.272.0",
-            "@aws-sdk/middleware-recursion-detection": "3.272.0",
-            "@aws-sdk/middleware-retry": "3.272.0",
-            "@aws-sdk/middleware-serde": "3.272.0",
-            "@aws-sdk/middleware-stack": "3.272.0",
-            "@aws-sdk/middleware-user-agent": "3.272.0",
-            "@aws-sdk/node-config-provider": "3.272.0",
-            "@aws-sdk/node-http-handler": "3.272.0",
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/smithy-client": "3.279.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/url-parser": "3.272.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-            "@aws-sdk/util-defaults-mode-node": "3.279.0",
-            "@aws-sdk/util-endpoints": "3.272.0",
-            "@aws-sdk/util-retry": "3.272.0",
-            "@aws-sdk/util-user-agent-browser": "3.272.0",
-            "@aws-sdk/util-user-agent-node": "3.272.0",
-            "@aws-sdk/util-utf8": "3.254.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/config-resolver": "3.310.0",
+            "@aws-sdk/fetch-http-handler": "3.310.0",
+            "@aws-sdk/hash-node": "3.310.0",
+            "@aws-sdk/invalid-dependency": "3.310.0",
+            "@aws-sdk/middleware-content-length": "3.310.0",
+            "@aws-sdk/middleware-endpoint": "3.310.0",
+            "@aws-sdk/middleware-host-header": "3.310.0",
+            "@aws-sdk/middleware-logger": "3.310.0",
+            "@aws-sdk/middleware-recursion-detection": "3.310.0",
+            "@aws-sdk/middleware-retry": "3.310.0",
+            "@aws-sdk/middleware-serde": "3.310.0",
+            "@aws-sdk/middleware-stack": "3.310.0",
+            "@aws-sdk/middleware-user-agent": "3.319.0",
+            "@aws-sdk/node-config-provider": "3.310.0",
+            "@aws-sdk/node-http-handler": "3.310.0",
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/smithy-client": "3.316.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/url-parser": "3.310.0",
+            "@aws-sdk/util-base64": "3.310.0",
+            "@aws-sdk/util-body-length-browser": "3.310.0",
+            "@aws-sdk/util-body-length-node": "3.310.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+            "@aws-sdk/util-defaults-mode-node": "3.316.0",
+            "@aws-sdk/util-endpoints": "3.319.0",
+            "@aws-sdk/util-retry": "3.310.0",
+            "@aws-sdk/util-user-agent-browser": "3.310.0",
+            "@aws-sdk/util-user-agent-node": "3.310.0",
+            "@aws-sdk/util-utf8": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/client-sts": {
-          "version": "3.281.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.281.0.tgz",
-          "integrity": "sha512-w8QomyhCVEArRcXgOkjbofiS/PLEKWRAyYBovjMS1cGhns2ZYJXFgHNgr3VGE54TghUc5dR1CqKuBKKM4ThrgA==",
+          "version": "3.319.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.319.0.tgz",
+          "integrity": "sha512-PRGGKCSKtyM3x629J9j4DMsH1cQT8UGW+R67u9Q5HrMK05gfjpmg+X1DQ3pgve4D8MI4R/Cm3NkYl2eUTbQHQg==",
           "requires": {
             "@aws-crypto/sha256-browser": "3.0.0",
             "@aws-crypto/sha256-js": "3.0.0",
-            "@aws-sdk/config-resolver": "3.272.0",
-            "@aws-sdk/credential-provider-node": "3.281.0",
-            "@aws-sdk/fetch-http-handler": "3.272.0",
-            "@aws-sdk/hash-node": "3.272.0",
-            "@aws-sdk/invalid-dependency": "3.272.0",
-            "@aws-sdk/middleware-content-length": "3.272.0",
-            "@aws-sdk/middleware-endpoint": "3.272.0",
-            "@aws-sdk/middleware-host-header": "3.278.0",
-            "@aws-sdk/middleware-logger": "3.272.0",
-            "@aws-sdk/middleware-recursion-detection": "3.272.0",
-            "@aws-sdk/middleware-retry": "3.272.0",
-            "@aws-sdk/middleware-sdk-sts": "3.272.0",
-            "@aws-sdk/middleware-serde": "3.272.0",
-            "@aws-sdk/middleware-signing": "3.272.0",
-            "@aws-sdk/middleware-stack": "3.272.0",
-            "@aws-sdk/middleware-user-agent": "3.272.0",
-            "@aws-sdk/node-config-provider": "3.272.0",
-            "@aws-sdk/node-http-handler": "3.272.0",
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/smithy-client": "3.279.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/url-parser": "3.272.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-            "@aws-sdk/util-defaults-mode-node": "3.279.0",
-            "@aws-sdk/util-endpoints": "3.272.0",
-            "@aws-sdk/util-retry": "3.272.0",
-            "@aws-sdk/util-user-agent-browser": "3.272.0",
-            "@aws-sdk/util-user-agent-node": "3.272.0",
-            "@aws-sdk/util-utf8": "3.254.0",
+            "@aws-sdk/config-resolver": "3.310.0",
+            "@aws-sdk/credential-provider-node": "3.319.0",
+            "@aws-sdk/fetch-http-handler": "3.310.0",
+            "@aws-sdk/hash-node": "3.310.0",
+            "@aws-sdk/invalid-dependency": "3.310.0",
+            "@aws-sdk/middleware-content-length": "3.310.0",
+            "@aws-sdk/middleware-endpoint": "3.310.0",
+            "@aws-sdk/middleware-host-header": "3.310.0",
+            "@aws-sdk/middleware-logger": "3.310.0",
+            "@aws-sdk/middleware-recursion-detection": "3.310.0",
+            "@aws-sdk/middleware-retry": "3.310.0",
+            "@aws-sdk/middleware-sdk-sts": "3.310.0",
+            "@aws-sdk/middleware-serde": "3.310.0",
+            "@aws-sdk/middleware-signing": "3.310.0",
+            "@aws-sdk/middleware-stack": "3.310.0",
+            "@aws-sdk/middleware-user-agent": "3.319.0",
+            "@aws-sdk/node-config-provider": "3.310.0",
+            "@aws-sdk/node-http-handler": "3.310.0",
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/smithy-client": "3.316.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/url-parser": "3.310.0",
+            "@aws-sdk/util-base64": "3.310.0",
+            "@aws-sdk/util-body-length-browser": "3.310.0",
+            "@aws-sdk/util-body-length-node": "3.310.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+            "@aws-sdk/util-defaults-mode-node": "3.316.0",
+            "@aws-sdk/util-endpoints": "3.319.0",
+            "@aws-sdk/util-retry": "3.310.0",
+            "@aws-sdk/util-user-agent-browser": "3.310.0",
+            "@aws-sdk/util-user-agent-node": "3.310.0",
+            "@aws-sdk/util-utf8": "3.310.0",
             "fast-xml-parser": "4.1.2",
-            "tslib": "^2.3.1"
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/config-resolver": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.272.0.tgz",
-          "integrity": "sha512-Dr4CffRVNsOp3LRNdpvcH6XuSgXOSLblWliCy/5I86cNl567KVMxujVx6uPrdTXYs2h1rt3MNl6jQGnAiJeTbw==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.310.0.tgz",
+          "integrity": "sha512-8vsT+/50lOqfDxka9m/rRt6oxv1WuGZoP8oPMk0Dt+TxXMbAzf4+rejBgiB96wshI1k3gLokYRjSQZn+dDtT8g==",
           "requires": {
-            "@aws-sdk/signature-v4": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/util-config-provider": "3.208.0",
-            "@aws-sdk/util-middleware": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-config-provider": "3.310.0",
+            "@aws-sdk/util-middleware": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/credential-provider-env": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.272.0.tgz",
-          "integrity": "sha512-QI65NbLnKLYHyTYhXaaUrq6eVsCCrMUb05WDA7+TJkWkjXesovpjc8vUKgFiLSxmgKmb2uOhHNcDyObKMrYQFw==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.310.0.tgz",
+          "integrity": "sha512-vvIPQpI16fj95xwS7M3D48F7QhZJBnnCgB5lR+b7So+vsG9ibm1mZRVGzVpdxCvgyOhHFbvrby9aalNJmmIP1A==",
           "requires": {
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/credential-provider-imds": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.272.0.tgz",
-          "integrity": "sha512-wwAfVY1jTFQEfxVfdYD5r5ieYGl+0g4nhekVxNMqE8E1JeRDd18OqiwAflzpgBIqxfqvCUkf+vl5JYyacMkNAQ==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.310.0.tgz",
+          "integrity": "sha512-baxK7Zp6dai5AGW01FIW27xS2KAaPUmKLIXv5SvFYsUgXXvNW55im4uG3b+2gA0F7V+hXvVBH08OEqmwW6we5w==",
           "requires": {
-            "@aws-sdk/node-config-provider": "3.272.0",
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/url-parser": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/node-config-provider": "3.310.0",
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/url-parser": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/credential-provider-ini": {
-          "version": "3.281.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.281.0.tgz",
-          "integrity": "sha512-H99nhMhHImQKgNhHKYc6usTS6UK8KzCcVGpILLVTuP97YlrYAMFAVstA3Xk6mZ28JAbHVXvI6vJjkMNOzCSKCA==",
+          "version": "3.319.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.319.0.tgz",
+          "integrity": "sha512-pzx388Fw1KlSgmIMUyRY8DJVYM3aXpwzjprD4RiQVPJeAI+t7oQmEvd2FiUZEuHDjWXcuonxgU+dk7i7HUk/HQ==",
           "requires": {
-            "@aws-sdk/credential-provider-env": "3.272.0",
-            "@aws-sdk/credential-provider-imds": "3.272.0",
-            "@aws-sdk/credential-provider-process": "3.272.0",
-            "@aws-sdk/credential-provider-sso": "3.281.0",
-            "@aws-sdk/credential-provider-web-identity": "3.272.0",
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/shared-ini-file-loader": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/credential-provider-env": "3.310.0",
+            "@aws-sdk/credential-provider-imds": "3.310.0",
+            "@aws-sdk/credential-provider-process": "3.310.0",
+            "@aws-sdk/credential-provider-sso": "3.319.0",
+            "@aws-sdk/credential-provider-web-identity": "3.310.0",
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/shared-ini-file-loader": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/credential-provider-node": {
-          "version": "3.281.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.281.0.tgz",
-          "integrity": "sha512-jhddd+lJp8G8hBJ+6glmXjfWJT3nxiE1aliH3fBC4RR3D+1kRXc99Xg6mbUb8bm+GrVZ4gzfiqSgg+ByKjd7xA==",
+          "version": "3.319.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.319.0.tgz",
+          "integrity": "sha512-DS4a0Rdd7ZtMshoeE+zuSgbC05YBcdzd0h89u/eX+1Yqx+HCjeb8WXkbXsz0Mwx8q9TE04aS8f6Bw9J4x4mO5g==",
           "requires": {
-            "@aws-sdk/credential-provider-env": "3.272.0",
-            "@aws-sdk/credential-provider-imds": "3.272.0",
-            "@aws-sdk/credential-provider-ini": "3.281.0",
-            "@aws-sdk/credential-provider-process": "3.272.0",
-            "@aws-sdk/credential-provider-sso": "3.281.0",
-            "@aws-sdk/credential-provider-web-identity": "3.272.0",
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/shared-ini-file-loader": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/credential-provider-env": "3.310.0",
+            "@aws-sdk/credential-provider-imds": "3.310.0",
+            "@aws-sdk/credential-provider-ini": "3.319.0",
+            "@aws-sdk/credential-provider-process": "3.310.0",
+            "@aws-sdk/credential-provider-sso": "3.319.0",
+            "@aws-sdk/credential-provider-web-identity": "3.310.0",
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/shared-ini-file-loader": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/credential-provider-process": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.272.0.tgz",
-          "integrity": "sha512-hiCAjWWm2PeBFp5cjkxqyam/XADjiS+e7GzwC34TbZn3LisS0uoweLojj9tD11NnnUhyhbLteUvu5+rotOLwrg==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.310.0.tgz",
+          "integrity": "sha512-h73sg6GPMUWC+3zMCbA1nZ2O03nNJt7G96JdmnantiXBwHpRKWW8nBTLzx5uhXn6hTuTaoQRP/P+oxQJKYdMmA==",
           "requires": {
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/shared-ini-file-loader": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/shared-ini-file-loader": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/credential-provider-sso": {
-          "version": "3.281.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.281.0.tgz",
-          "integrity": "sha512-IqJnpXuLpJYoSCf/Rt66/CPVTjfkam3z9+ZvlQJV+VbK+vGj276qEtTmSN3XPZZgF1XbWptvkzIWDszLhHiZmg==",
+          "version": "3.319.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.319.0.tgz",
+          "integrity": "sha512-gAUnWH41lxkIbANXu+Rz5zS0Iavjjmpf3C56vAMT7oaYZ3Cg/Ys5l2SwAucQGOCA2DdS2hDiSI8E+Yhr4F5toA==",
           "requires": {
-            "@aws-sdk/client-sso": "3.281.0",
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/shared-ini-file-loader": "3.272.0",
-            "@aws-sdk/token-providers": "3.281.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/client-sso": "3.319.0",
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/shared-ini-file-loader": "3.310.0",
+            "@aws-sdk/token-providers": "3.319.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/credential-provider-web-identity": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.272.0.tgz",
-          "integrity": "sha512-ImrHMkcgneGa/HadHAQXPwOrX26sAKuB8qlMxZF/ZCM2B55u8deY+ZVkVuraeKb7YsahMGehPFOfRAF6mvFI5Q==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.310.0.tgz",
+          "integrity": "sha512-H4SzuZXILNhK6/IR1uVvsUDZvzc051hem7GLyYghBCu8mU+tq28YhKE8MfSroi6eL2e5Vujloij1OM2EQQkPkw==",
           "requires": {
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/fetch-http-handler": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.272.0.tgz",
-          "integrity": "sha512-1Qhm9e0RbS1Xf4CZqUbQyUMkDLd7GrsRXWIvm9b86/vgeV8/WnjO3CMue9D51nYgcyQORhYXv6uVjAYCWbUExA==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.310.0.tgz",
+          "integrity": "sha512-Bi9vIwzdkw1zMcvi/zGzlWS9KfIEnAq4NNhsnCxbQ4OoIRU9wvU+WGZdBBhxg0ZxZmpp1j1aZhU53lLjA07MHw==",
           "requires": {
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/querystring-builder": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/querystring-builder": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-base64": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/hash-node": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.272.0.tgz",
-          "integrity": "sha512-40dwND+iAm3VtPHPZu7/+CIdVJFk2s0cWZt1lOiMPMSXycSYJ45wMk7Lly3uoqRx0uWfFK5iT2OCv+fJi5jTng==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.310.0.tgz",
+          "integrity": "sha512-NvE2fhRc8GRwCXBfDehxVAWCmVwVMILliAKVPAEr4yz2CkYs0tqU51S48x23dtna07H4qHtgpeNqVTthcIQOEQ==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/util-buffer-from": "3.208.0",
-            "@aws-sdk/util-utf8": "3.254.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-buffer-from": "3.310.0",
+            "@aws-sdk/util-utf8": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/invalid-dependency": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.272.0.tgz",
-          "integrity": "sha512-ysW6wbjl1Y78txHUQ/Tldj2Rg1BI7rpMO9B9xAF6yAX3mQ7t6SUPQG/ewOGvH2208NBIl3qP5e/hDf0Q6r/1iw==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.310.0.tgz",
+          "integrity": "sha512-1s5RG5rSPXoa/aZ/Kqr5U/7lqpx+Ry81GprQ2bxWqJvWQIJ0IRUwo5pk8XFxbKVr/2a+4lZT/c3OGoBOM1yRRA==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
+          "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
+          "requires": {
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/middleware-content-length": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.272.0.tgz",
-          "integrity": "sha512-sAbDZSTNmLX+UTGwlUHJBWy0QGQkiClpHwVFXACon+aG0ySLNeRKEVYs6NCPYldw4cj6hveLUn50cX44ukHErw==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.310.0.tgz",
+          "integrity": "sha512-P8tQZxgDt6CAh1wd/W6WPzjc+uWPJwQkm+F7rAwRlM+k9q17HrhnksGDKcpuuLyIhPQYdmOMIkpKVgXGa4avhQ==",
           "requires": {
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/middleware-endpoint": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.272.0.tgz",
-          "integrity": "sha512-Dk3JVjj7SxxoUKv3xGiOeBksvPtFhTDrVW75XJ98Ymv8gJH5L1sq4hIeJAHRKogGiRFq2J73mnZSlM9FVXEylg==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.310.0.tgz",
+          "integrity": "sha512-Z+N2vOL8K354/lstkClxLLsr6hCpVRh+0tCMXrVj66/NtKysCEZ/0b9LmqOwD9pWHNiI2mJqXwY0gxNlKAroUg==",
           "requires": {
-            "@aws-sdk/middleware-serde": "3.272.0",
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/signature-v4": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/url-parser": "3.272.0",
-            "@aws-sdk/util-config-provider": "3.208.0",
-            "@aws-sdk/util-middleware": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/middleware-serde": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/url-parser": "3.310.0",
+            "@aws-sdk/util-middleware": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/middleware-host-header": {
-          "version": "3.278.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.278.0.tgz",
-          "integrity": "sha512-oTkF3exy89KE8NgSeXFwD+0H0GRKL2qUw92t3caEj7+4KzU/0m3t7NtKlq2NLRtTJhZ/izYRpV536oogLzGm3g==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.310.0.tgz",
+          "integrity": "sha512-QWSA+46/hXorXyWa61ic2K7qZzwHTiwfk2e9mRRjeIRepUgI3qxFjsYqrWtrOGBjmFmq0pYIY8Bb/DCJuQqcoA==",
           "requires": {
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/middleware-logger": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.272.0.tgz",
-          "integrity": "sha512-u2SQ0hWrFwxbxxYMG5uMEgf01pQY5jauK/LYWgGIvuCmFgiyRQQP3oN7kkmsxnS9MWmNmhbyQguX2NY02s5e9w==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.310.0.tgz",
+          "integrity": "sha512-Lurm8XofrASBRnAVtiSNuDSRsRqPNg27RIFLLsLp/pqog9nFJ0vz0kgdb9S5Z+zw83Mm+UlqOe6D8NTUNp4fVg==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/middleware-recursion-detection": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.272.0.tgz",
-          "integrity": "sha512-Gp/eKWeUWVNiiBdmUM2qLkBv+VLSJKoWAO+aKmyxxwjjmWhE0FrfA1NQ1a3g+NGMhRbAfQdaYswRAKsul70ISg==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.310.0.tgz",
+          "integrity": "sha512-SuB75/xk/gyue24gkriTwO2jFd7YcUGZDClQYuRejgbXSa3CO0lWyawQtfLcSSEBp9izrEVXuFH24K1eAft5nQ==",
           "requires": {
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/middleware-retry": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.272.0.tgz",
-          "integrity": "sha512-pCGvHM7C76VbO/dFerH+Vwf7tGv7j+e+eGrvhQ35mRghCtfIou/WMfTZlD1TNee93crrAQQVZKjtW3dMB3WCzg==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.310.0.tgz",
+          "integrity": "sha512-oTPsRy2W4s+dfxbJPW7Km+hHtv/OMsNsVfThAq8DDYKC13qlr1aAyOqGLD+dpBy2aKe7ss517Sy2HcHtHqm7/g==",
           "requires": {
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/service-error-classification": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/util-middleware": "3.272.0",
-            "@aws-sdk/util-retry": "3.272.0",
-            "tslib": "^2.3.1",
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/service-error-classification": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-middleware": "3.310.0",
+            "@aws-sdk/util-retry": "3.310.0",
+            "tslib": "^2.5.0",
             "uuid": "^8.3.2"
           }
         },
         "@aws-sdk/middleware-sdk-sts": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.272.0.tgz",
-          "integrity": "sha512-VvYPg7LrDIjUOWueSzo2wBzcNG7dw+cmzV6zAKaLxf0RC5jeAP4hE0OzDiiZfDrjNghEzgq/V+0NO+LewqYL9Q==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.310.0.tgz",
+          "integrity": "sha512-+5PFwlYNLvLLIfw0ASAoWV/iIF8Zv6R6QGtyP0CclhRSvNjgbQDVnV0g95MC5qvh+GB/Yjlkt8qAjLSPjHfsrQ==",
           "requires": {
-            "@aws-sdk/middleware-signing": "3.272.0",
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/signature-v4": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/middleware-signing": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/middleware-serde": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.272.0.tgz",
-          "integrity": "sha512-kW1uOxgPSwtXPB5rm3QLdWomu42lkYpQL94tM1BjyFOWmBLO2lQhk5a7Dw6HkTozT9a+vxtscLChRa6KZe61Hw==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.310.0.tgz",
+          "integrity": "sha512-RNeeTVWSLTaentUeCgQKZhAl+C6hxtwD78cQWS10UymWpQFwbaxztzKUu4UQS5xA2j6PxwPRRUjqa4jcFjfLsg==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/middleware-signing": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.272.0.tgz",
-          "integrity": "sha512-4LChFK4VAR91X+dupqM8fQqYhFGE0G4Bf9rQlVTgGSbi2KUOmpqXzH0/WKE228nKuEhmH8+Qd2VPSAE2JcyAUA==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.310.0.tgz",
+          "integrity": "sha512-f9mKq+XMdW207Af3hKjdTnpNhdtwqWuvFs/ZyXoOkp/g1MY1O6L23Jy6i52m29LxbT4AuNRG1oKODfXM0vYVjQ==",
           "requires": {
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/signature-v4": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/util-middleware": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/signature-v4": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-middleware": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/middleware-stack": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.272.0.tgz",
-          "integrity": "sha512-jhwhknnPBGhfXAGV5GXUWfEhDFoP/DN8MPCO2yC5OAxyp6oVJ8lTPLkZYMTW5VL0c0eG44dXpF4Ib01V+PlDrQ==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.310.0.tgz",
+          "integrity": "sha512-010O1PD+UAcZVKRvqEusE1KJqN96wwrf6QsqbRM0ywsKQ21NDweaHvEDlds2VHpgmofxkRLRu/IDrlPkKRQrRg==",
           "requires": {
-            "tslib": "^2.3.1"
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/middleware-user-agent": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.272.0.tgz",
-          "integrity": "sha512-Qy7/0fsDJxY5l0bEk7WKDfqb4Os/sCAgFR2zEvrhDtbkhYPf72ysvg/nRUTncmCbo8tOok4SJii2myk8KMfjjw==",
+          "version": "3.319.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.319.0.tgz",
+          "integrity": "sha512-ytaLx2dlR5AdMSne6FuDCISVg8hjyKj+cHU20b2CRA/E/z+XXrLrssp4JrCgizRKPPUep0psMIa22Zd6osTT5Q==",
           "requires": {
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-endpoints": "3.319.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/node-config-provider": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.272.0.tgz",
-          "integrity": "sha512-YYCIBh9g1EQo7hm2l22HX5Yr9RoPQ2RCvhzKvF1n1e8t1QH4iObQrYUtqHG4khcm64Cft8C5MwZmgzHbya5Z6Q==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.310.0.tgz",
+          "integrity": "sha512-T/Pp6htc6hq/Cq+MLNDSyiwWCMVF6GqbBbXKVlO5L8rdHx4sq9xPdoPveZhGWrxvkanjA6eCwUp6E0riBOSVng==",
           "requires": {
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/shared-ini-file-loader": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/shared-ini-file-loader": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/node-http-handler": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.272.0.tgz",
-          "integrity": "sha512-VrW9PjhhngeyYp4yGYPe5S0vgZH6NwU3Po9xAgayUeE37Inr7LS1YteFMHdpgsUUeNXnh7d06CXqHo1XjtqOKA==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.310.0.tgz",
+          "integrity": "sha512-irv9mbcM9xC2xYjArQF5SYmHBMu4ciMWtGsoHII1nRuFOl9FoT4ffTvEPuLlfC6pznzvKt9zvnm6xXj7gDChKg==",
           "requires": {
-            "@aws-sdk/abort-controller": "3.272.0",
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/querystring-builder": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/abort-controller": "3.310.0",
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/querystring-builder": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/property-provider": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.272.0.tgz",
-          "integrity": "sha512-V1pZTaH5eqpAt8O8CzbItHhOtzIfFuWymvwZFkAtwKuaHpnl7jjrTouV482zoq8AD/fF+VVSshwBKYA7bhidIw==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.310.0.tgz",
+          "integrity": "sha512-3lxDb0akV6BBzmFe4nLPaoliQbAifyWJhuvuDOu7e8NzouvpQXs0275w9LePhhcgjKAEVXUIse05ZW2DLbxo/g==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/protocol-http": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.272.0.tgz",
-          "integrity": "sha512-4JQ54v5Yn08jspNDeHo45CaSn1CvTJqS1Ywgr79eU6jBExtguOWv6LNtwVSBD9X37v88iqaxt8iu1Z3pZZAJeg==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.310.0.tgz",
+          "integrity": "sha512-fgZ1aw/irQtnrsR58pS8ThKOWo57Py3xX6giRvwSgZDEcxHfVzuQjy9yPuV++v04fdmdtgpbGf8WfvAAJ11yXQ==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/querystring-builder": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.272.0.tgz",
-          "integrity": "sha512-ndo++7GkdCj5tBXE6rGcITpSpZS4PfyV38wntGYAlj9liL1omk3bLZRY6uzqqkJpVHqbg2fD7O2qHNItzZgqhw==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.310.0.tgz",
+          "integrity": "sha512-ZHH8GV/80+pWGo7DzsvwvXR5xVxUHXUvPJPFAkhr6nCf78igdoF8gR10ScFoEKbtEapoNTaZlKHPXxpD8aPG7A==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/util-uri-escape": "3.201.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-uri-escape": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/querystring-parser": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.272.0.tgz",
-          "integrity": "sha512-5oS4/9n6N1LZW9tI3qq/0GnCuWoOXRgcHVB+AJLRBvDbEe+GI+C/xK1tKLsfpDNgsQJHc4IPQoIt4megyZ/1+A==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.310.0.tgz",
+          "integrity": "sha512-YkIznoP6lsiIUHinx++/lbb3tlMURGGqMpo0Pnn32zYzGrJXA6eC3D0as2EcMjo55onTfuLcIiX4qzXes2MYOA==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/service-error-classification": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.272.0.tgz",
-          "integrity": "sha512-REoltM1LK9byyIufLqx9znhSolPcHQgVHIA2S0zu5sdt5qER4OubkLAXuo4MBbisUTmh8VOOvIyUb5ijZCXq1w=="
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.310.0.tgz",
+          "integrity": "sha512-PuyC7k3qfIKeH2LCnDwbttMOKq3qAx4buvg0yfnJtQOz6t1AR8gsnAq0CjKXXyfkXwNKWTqCpE6lVNUIkXgsMw=="
         },
         "@aws-sdk/shared-ini-file-loader": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.272.0.tgz",
-          "integrity": "sha512-lzFPohp5sy2XvwFjZIzLVCRpC0i5cwBiaXmFzXYQZJm6FSCszHO4ax+m9yrtlyVFF/2YPWl+/bzNthy4aJtseA==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.310.0.tgz",
+          "integrity": "sha512-N0q9pG0xSjQwc690YQND5bofm+4nfUviQ/Ppgan2kU6aU0WUq8KwgHJBto/YEEI+VlrME30jZJnxtOvcZJc2XA==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/signature-v4": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.272.0.tgz",
-          "integrity": "sha512-pWxnHG1NqJWMwlhJ6NHNiUikOL00DHROmxah6krJPMPq4I3am2KY2Rs/8ouWhnEXKaHAv4EQhSALJ+7Mq5S4/A==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.310.0.tgz",
+          "integrity": "sha512-1M60P1ZBNAjCFv9sYW29OF6okktaeibWyW3lMXqzoHF70lHBZh+838iUchznXUA5FLabfn4jBFWMRxlAXJUY2Q==",
           "requires": {
-            "@aws-sdk/is-array-buffer": "3.201.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/util-hex-encoding": "3.201.0",
-            "@aws-sdk/util-middleware": "3.272.0",
-            "@aws-sdk/util-uri-escape": "3.201.0",
-            "@aws-sdk/util-utf8": "3.254.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/is-array-buffer": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-hex-encoding": "3.310.0",
+            "@aws-sdk/util-middleware": "3.310.0",
+            "@aws-sdk/util-uri-escape": "3.310.0",
+            "@aws-sdk/util-utf8": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/smithy-client": {
-          "version": "3.279.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.279.0.tgz",
-          "integrity": "sha512-ZcYWUQDGAYN6NXRpJuSn46PetrpPCA6TrDVwP9+3pERzTXZ66npXoG2XhHjNrOXy/Ted5A3OxKrM4/zLu9tK3A==",
+          "version": "3.316.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.316.0.tgz",
+          "integrity": "sha512-6YXOKbRnXeS8r8RWzuL6JMBolDYM5Wa4fD/VY6x/wK78i2xErHOvqzHgyyeLI1MMw4uqyd4wRNJNWC9TMPduXw==",
           "requires": {
-            "@aws-sdk/middleware-stack": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/middleware-stack": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/token-providers": {
-          "version": "3.281.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.281.0.tgz",
-          "integrity": "sha512-36Vg/F6Edm7qdjcTeNVON+sK2edgHhmhTtAEjWcuUk5AX/Et+Ate/A2N8HD3nxwlAcgidfnBC9SHYJatbhcEnQ==",
+          "version": "3.319.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.319.0.tgz",
+          "integrity": "sha512-5utg6VL6Pl0uiLUn8ZJPYYxzCb9VRPsgJmGXktRUwq0YlTJ6ABcaxTXwZcC++sjh/qyCQDK5PPLNU5kIBttHMQ==",
           "requires": {
-            "@aws-sdk/client-sso-oidc": "3.281.0",
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/shared-ini-file-loader": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/client-sso-oidc": "3.319.0",
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/shared-ini-file-loader": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/types": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.272.0.tgz",
-          "integrity": "sha512-MmmL6vxMGP5Bsi+4wRx4mxYlU/LX6M0noOXrDh/x5FfG7/4ZOar/nDxqDadhJtNM88cuWVHZWY59P54JzkGWmA==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.310.0.tgz",
+          "integrity": "sha512-j8eamQJ7YcIhw7fneUfs8LYl3t01k4uHi4ZDmNRgtbmbmTTG3FZc2MotStZnp3nZB6vLiPF1o5aoJxWVvkzS6A==",
           "requires": {
-            "tslib": "^2.3.1"
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/url-parser": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.272.0.tgz",
-          "integrity": "sha512-vX/Tx02PlnQ/Kgtf5TnrNDHPNbY+amLZjW0Z1d9vzAvSZhQ4i9Y18yxoRDIaDTCNVRDjdhV8iuctW+05PB5JtQ==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.310.0.tgz",
+          "integrity": "sha512-mCLnCaSB9rQvAgx33u0DujLvr4d5yEm/W5r789GblwwQnlNXedVu50QRizMLTpltYWyAUoXjJgQnJHmJMaKXhw==",
           "requires": {
-            "@aws-sdk/querystring-parser": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/querystring-parser": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-base64": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
+          "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-body-length-browser": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
+          "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
+          "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
+          "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-config-provider": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
+          "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
+          "requires": {
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/util-defaults-mode-browser": {
-          "version": "3.279.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.279.0.tgz",
-          "integrity": "sha512-RnchYRrpapTT5Hu23LOfk6e8RMVq0kUzho6xA6TJj1a4uGxkcRMvgzPipCq1P5uHu0mrkQBg9pGPEVNOUs38/Q==",
+          "version": "3.316.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.316.0.tgz",
+          "integrity": "sha512-6FSqLhYmaihtH2n1s4b2rlLW0ABU8N6VZIfzLfe2ING4PF0MzfaMMhnTFUHVXfKCVGoR8yP6iyFTRCyHGVEL1w==",
           "requires": {
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
             "bowser": "^2.11.0",
-            "tslib": "^2.3.1"
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/util-defaults-mode-node": {
-          "version": "3.279.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.279.0.tgz",
-          "integrity": "sha512-A2NB10xReWC+GSnOivKGZ9rnljIZdEP8WMCQQEnA6DJNI19AUFF/O9QJ9y+cHGLKEms7jH86Y99wShdpzAK+Jw==",
+          "version": "3.316.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.316.0.tgz",
+          "integrity": "sha512-dkYy10hdjPSScXXvnjGpZpnJxllkb6ICHgLMwZ4JczLHhPM12T/4PQ758YN8HS+muiYDGX1Bl2z1jd/bMcewBQ==",
           "requires": {
-            "@aws-sdk/config-resolver": "3.272.0",
-            "@aws-sdk/credential-provider-imds": "3.272.0",
-            "@aws-sdk/node-config-provider": "3.272.0",
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/config-resolver": "3.310.0",
+            "@aws-sdk/credential-provider-imds": "3.310.0",
+            "@aws-sdk/node-config-provider": "3.310.0",
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/util-endpoints": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.272.0.tgz",
-          "integrity": "sha512-c4MPUaJt2G6gGpoiwIOqDfUa98c1J63RpYvf/spQEKOtC/tF5Gfqlxuq8FnAl5lHnrqj1B9ZXLLxFhHtDR0IiQ==",
+          "version": "3.319.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.319.0.tgz",
+          "integrity": "sha512-3I64UMoYA2e2++oOUJXRcFtYLpLylnZFRltWfPo1B3dLlf+MIWat9djT+mMus+hW1ntLsvAIVu1hLVePJC0gvw==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
+          "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
+          "requires": {
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/util-middleware": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.272.0.tgz",
-          "integrity": "sha512-Abw8m30arbwxqmeMMha5J11ESpHUNmCeSqSzE8/C4B8jZQtHY4kq7f+upzcNIQ11lsd+uzBEzNG3+dDRi0XOJQ==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.310.0.tgz",
+          "integrity": "sha512-FTSUKL/eRb9X6uEZClrTe27QFXUNNp7fxYrPndZwk1hlaOP5ix+MIHBcI7pIiiY/JPfOUmPyZOu+HetlFXjWog==",
           "requires": {
-            "tslib": "^2.3.1"
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/util-retry": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.272.0.tgz",
-          "integrity": "sha512-Ngha5414LR4gRHURVKC9ZYXsEJhMkm+SJ+44wlzOhavglfdcKKPUsibz5cKY1jpUV7oKECwaxHWpBB8r6h+hOg==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.310.0.tgz",
+          "integrity": "sha512-FwWGhCBLfoivTMUHu1LIn4NjrN9JLJ/aX5aZmbcPIOhZVFJj638j0qDgZXyfvVqBuBZh7M8kGq0Oahy3dp69OA==",
           "requires": {
-            "@aws-sdk/service-error-classification": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/service-error-classification": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
+          "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
+          "requires": {
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/util-user-agent-browser": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.272.0.tgz",
-          "integrity": "sha512-Lp5QX5bH6uuwBlIdr7w7OAcAI50ttyskb++yUr9i+SPvj6RI2dsfIBaK4mDg1qUdM5LeUdvIyqwj3XHjFKAAvA==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.310.0.tgz",
+          "integrity": "sha512-yU/4QnHHuQ5z3vsUqMQVfYLbZGYwpYblPiuZx4Zo9+x0PBkNjYMqctdDcrpoH9Z2xZiDN16AmQGK1tix117ZKw==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
+            "@aws-sdk/types": "3.310.0",
             "bowser": "^2.11.0",
-            "tslib": "^2.3.1"
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/util-user-agent-node": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.272.0.tgz",
-          "integrity": "sha512-ljK+R3l+Q1LIHrcR+Knhk0rmcSkfFadZ8V+crEGpABf/QUQRg7NkZMsoe814tfBO5F7tMxo8wwwSdaVNNHtoRA==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.310.0.tgz",
+          "integrity": "sha512-Ra3pEl+Gn2BpeE7KiDGpi4zj7WJXZA5GXnGo3mjbi9+Y3zrbuhJAbdZO3mO/o7xDgMC6ph4xCTbaSGzU6b6EDg==",
           "requires": {
-            "@aws-sdk/node-config-provider": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/node-config-provider": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "fast-xml-parser": {
@@ -20143,46 +20735,46 @@
       }
     },
     "@aws-sdk/client-iotsitewise": {
-      "version": "3.281.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-iotsitewise/-/client-iotsitewise-3.281.0.tgz",
-      "integrity": "sha512-1Mz5DBBiw4JNrtcmMvIWk+8V+YVfRBG81GuikF7FBuqdICuEuVoZODPcLSOjXvjW6uRwBPuauPqRwnUXCqocXQ==",
+      "version": "3.319.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-iotsitewise/-/client-iotsitewise-3.319.0.tgz",
+      "integrity": "sha512-DrMT1MpHgEPyfZrle7RNB6/uIdLTNPue22KIc9Mlpv1Ykd9BAUH02KG/74A1xCvPxduS66n0ceufJa5APfBtmA==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.281.0",
-        "@aws-sdk/config-resolver": "3.272.0",
-        "@aws-sdk/credential-provider-node": "3.281.0",
-        "@aws-sdk/fetch-http-handler": "3.272.0",
-        "@aws-sdk/hash-node": "3.272.0",
-        "@aws-sdk/invalid-dependency": "3.272.0",
-        "@aws-sdk/middleware-content-length": "3.272.0",
-        "@aws-sdk/middleware-endpoint": "3.272.0",
-        "@aws-sdk/middleware-host-header": "3.278.0",
-        "@aws-sdk/middleware-logger": "3.272.0",
-        "@aws-sdk/middleware-recursion-detection": "3.272.0",
-        "@aws-sdk/middleware-retry": "3.272.0",
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/middleware-signing": "3.272.0",
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/middleware-user-agent": "3.272.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/node-http-handler": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/smithy-client": "3.279.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-        "@aws-sdk/util-defaults-mode-node": "3.279.0",
-        "@aws-sdk/util-endpoints": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "@aws-sdk/util-user-agent-browser": "3.272.0",
-        "@aws-sdk/util-user-agent-node": "3.272.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "@aws-sdk/util-waiter": "3.272.0",
-        "tslib": "^2.3.1",
+        "@aws-sdk/client-sts": "3.319.0",
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/credential-provider-node": "3.319.0",
+        "@aws-sdk/fetch-http-handler": "3.310.0",
+        "@aws-sdk/hash-node": "3.310.0",
+        "@aws-sdk/invalid-dependency": "3.310.0",
+        "@aws-sdk/middleware-content-length": "3.310.0",
+        "@aws-sdk/middleware-endpoint": "3.310.0",
+        "@aws-sdk/middleware-host-header": "3.310.0",
+        "@aws-sdk/middleware-logger": "3.310.0",
+        "@aws-sdk/middleware-recursion-detection": "3.310.0",
+        "@aws-sdk/middleware-retry": "3.310.0",
+        "@aws-sdk/middleware-serde": "3.310.0",
+        "@aws-sdk/middleware-signing": "3.310.0",
+        "@aws-sdk/middleware-stack": "3.310.0",
+        "@aws-sdk/middleware-user-agent": "3.319.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/node-http-handler": "3.310.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/smithy-client": "3.316.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+        "@aws-sdk/util-defaults-mode-node": "3.316.0",
+        "@aws-sdk/util-endpoints": "3.319.0",
+        "@aws-sdk/util-retry": "3.310.0",
+        "@aws-sdk/util-user-agent-browser": "3.310.0",
+        "@aws-sdk/util-user-agent-node": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@aws-sdk/util-waiter": "3.310.0",
+        "tslib": "^2.5.0",
         "uuid": "^8.3.2"
       },
       "dependencies": {
@@ -20273,585 +20865,645 @@
           }
         },
         "@aws-sdk/abort-controller": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.272.0.tgz",
-          "integrity": "sha512-s2TV3phapcTwZNr4qLxbfuQuE9ZMP4RoJdkvRRCkKdm6jslsWLJf2Zlcxti/23hOlINUMYv2iXE2pftIgWGdpg==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.310.0.tgz",
+          "integrity": "sha512-v1zrRQxDLA1MdPim159Vx/CPHqsB4uybSxRi1CnfHO5ZjHryx3a5htW2gdGAykVCul40+yJXvfpufMrELVxH+g==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/client-sso": {
-          "version": "3.281.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.281.0.tgz",
-          "integrity": "sha512-3RvO5zClQhu37w9VMLoHPGk58S3y8Spb7XX8rW51bm5TUglYQskQ0X2VLEUW/7ZGx/peokHws9Z9+w5yGq5sdA==",
+          "version": "3.319.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.319.0.tgz",
+          "integrity": "sha512-g46KgAjRiYBS8Oi85DPwSAQpt+Hgmw/YFgGVwZqMfTL70KNJwLFKRa5D9UocQd7t7OjPRdKF7g0Gp5peyAK9dw==",
           "requires": {
             "@aws-crypto/sha256-browser": "3.0.0",
             "@aws-crypto/sha256-js": "3.0.0",
-            "@aws-sdk/config-resolver": "3.272.0",
-            "@aws-sdk/fetch-http-handler": "3.272.0",
-            "@aws-sdk/hash-node": "3.272.0",
-            "@aws-sdk/invalid-dependency": "3.272.0",
-            "@aws-sdk/middleware-content-length": "3.272.0",
-            "@aws-sdk/middleware-endpoint": "3.272.0",
-            "@aws-sdk/middleware-host-header": "3.278.0",
-            "@aws-sdk/middleware-logger": "3.272.0",
-            "@aws-sdk/middleware-recursion-detection": "3.272.0",
-            "@aws-sdk/middleware-retry": "3.272.0",
-            "@aws-sdk/middleware-serde": "3.272.0",
-            "@aws-sdk/middleware-stack": "3.272.0",
-            "@aws-sdk/middleware-user-agent": "3.272.0",
-            "@aws-sdk/node-config-provider": "3.272.0",
-            "@aws-sdk/node-http-handler": "3.272.0",
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/smithy-client": "3.279.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/url-parser": "3.272.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-            "@aws-sdk/util-defaults-mode-node": "3.279.0",
-            "@aws-sdk/util-endpoints": "3.272.0",
-            "@aws-sdk/util-retry": "3.272.0",
-            "@aws-sdk/util-user-agent-browser": "3.272.0",
-            "@aws-sdk/util-user-agent-node": "3.272.0",
-            "@aws-sdk/util-utf8": "3.254.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/config-resolver": "3.310.0",
+            "@aws-sdk/fetch-http-handler": "3.310.0",
+            "@aws-sdk/hash-node": "3.310.0",
+            "@aws-sdk/invalid-dependency": "3.310.0",
+            "@aws-sdk/middleware-content-length": "3.310.0",
+            "@aws-sdk/middleware-endpoint": "3.310.0",
+            "@aws-sdk/middleware-host-header": "3.310.0",
+            "@aws-sdk/middleware-logger": "3.310.0",
+            "@aws-sdk/middleware-recursion-detection": "3.310.0",
+            "@aws-sdk/middleware-retry": "3.310.0",
+            "@aws-sdk/middleware-serde": "3.310.0",
+            "@aws-sdk/middleware-stack": "3.310.0",
+            "@aws-sdk/middleware-user-agent": "3.319.0",
+            "@aws-sdk/node-config-provider": "3.310.0",
+            "@aws-sdk/node-http-handler": "3.310.0",
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/smithy-client": "3.316.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/url-parser": "3.310.0",
+            "@aws-sdk/util-base64": "3.310.0",
+            "@aws-sdk/util-body-length-browser": "3.310.0",
+            "@aws-sdk/util-body-length-node": "3.310.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+            "@aws-sdk/util-defaults-mode-node": "3.316.0",
+            "@aws-sdk/util-endpoints": "3.319.0",
+            "@aws-sdk/util-retry": "3.310.0",
+            "@aws-sdk/util-user-agent-browser": "3.310.0",
+            "@aws-sdk/util-user-agent-node": "3.310.0",
+            "@aws-sdk/util-utf8": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/client-sso-oidc": {
-          "version": "3.281.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.281.0.tgz",
-          "integrity": "sha512-P6zf9pDuxApVoCYStAg7L8BU9AcWI8PxfLSX4r2WnmcQropxzPJ3op1j9nvbwwBDMFWephijVY4AVp8MqPcPyg==",
+          "version": "3.319.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.319.0.tgz",
+          "integrity": "sha512-GJBgT/tephRZY3oTbDBMv+G9taoqKUIvGPn+7shmzz2P1SerutsRSfKfDXV+VptPNRoGmjjCLPmWjMFYbFKILQ==",
           "requires": {
             "@aws-crypto/sha256-browser": "3.0.0",
             "@aws-crypto/sha256-js": "3.0.0",
-            "@aws-sdk/config-resolver": "3.272.0",
-            "@aws-sdk/fetch-http-handler": "3.272.0",
-            "@aws-sdk/hash-node": "3.272.0",
-            "@aws-sdk/invalid-dependency": "3.272.0",
-            "@aws-sdk/middleware-content-length": "3.272.0",
-            "@aws-sdk/middleware-endpoint": "3.272.0",
-            "@aws-sdk/middleware-host-header": "3.278.0",
-            "@aws-sdk/middleware-logger": "3.272.0",
-            "@aws-sdk/middleware-recursion-detection": "3.272.0",
-            "@aws-sdk/middleware-retry": "3.272.0",
-            "@aws-sdk/middleware-serde": "3.272.0",
-            "@aws-sdk/middleware-stack": "3.272.0",
-            "@aws-sdk/middleware-user-agent": "3.272.0",
-            "@aws-sdk/node-config-provider": "3.272.0",
-            "@aws-sdk/node-http-handler": "3.272.0",
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/smithy-client": "3.279.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/url-parser": "3.272.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-            "@aws-sdk/util-defaults-mode-node": "3.279.0",
-            "@aws-sdk/util-endpoints": "3.272.0",
-            "@aws-sdk/util-retry": "3.272.0",
-            "@aws-sdk/util-user-agent-browser": "3.272.0",
-            "@aws-sdk/util-user-agent-node": "3.272.0",
-            "@aws-sdk/util-utf8": "3.254.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/config-resolver": "3.310.0",
+            "@aws-sdk/fetch-http-handler": "3.310.0",
+            "@aws-sdk/hash-node": "3.310.0",
+            "@aws-sdk/invalid-dependency": "3.310.0",
+            "@aws-sdk/middleware-content-length": "3.310.0",
+            "@aws-sdk/middleware-endpoint": "3.310.0",
+            "@aws-sdk/middleware-host-header": "3.310.0",
+            "@aws-sdk/middleware-logger": "3.310.0",
+            "@aws-sdk/middleware-recursion-detection": "3.310.0",
+            "@aws-sdk/middleware-retry": "3.310.0",
+            "@aws-sdk/middleware-serde": "3.310.0",
+            "@aws-sdk/middleware-stack": "3.310.0",
+            "@aws-sdk/middleware-user-agent": "3.319.0",
+            "@aws-sdk/node-config-provider": "3.310.0",
+            "@aws-sdk/node-http-handler": "3.310.0",
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/smithy-client": "3.316.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/url-parser": "3.310.0",
+            "@aws-sdk/util-base64": "3.310.0",
+            "@aws-sdk/util-body-length-browser": "3.310.0",
+            "@aws-sdk/util-body-length-node": "3.310.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+            "@aws-sdk/util-defaults-mode-node": "3.316.0",
+            "@aws-sdk/util-endpoints": "3.319.0",
+            "@aws-sdk/util-retry": "3.310.0",
+            "@aws-sdk/util-user-agent-browser": "3.310.0",
+            "@aws-sdk/util-user-agent-node": "3.310.0",
+            "@aws-sdk/util-utf8": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/client-sts": {
-          "version": "3.281.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.281.0.tgz",
-          "integrity": "sha512-w8QomyhCVEArRcXgOkjbofiS/PLEKWRAyYBovjMS1cGhns2ZYJXFgHNgr3VGE54TghUc5dR1CqKuBKKM4ThrgA==",
+          "version": "3.319.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.319.0.tgz",
+          "integrity": "sha512-PRGGKCSKtyM3x629J9j4DMsH1cQT8UGW+R67u9Q5HrMK05gfjpmg+X1DQ3pgve4D8MI4R/Cm3NkYl2eUTbQHQg==",
           "requires": {
             "@aws-crypto/sha256-browser": "3.0.0",
             "@aws-crypto/sha256-js": "3.0.0",
-            "@aws-sdk/config-resolver": "3.272.0",
-            "@aws-sdk/credential-provider-node": "3.281.0",
-            "@aws-sdk/fetch-http-handler": "3.272.0",
-            "@aws-sdk/hash-node": "3.272.0",
-            "@aws-sdk/invalid-dependency": "3.272.0",
-            "@aws-sdk/middleware-content-length": "3.272.0",
-            "@aws-sdk/middleware-endpoint": "3.272.0",
-            "@aws-sdk/middleware-host-header": "3.278.0",
-            "@aws-sdk/middleware-logger": "3.272.0",
-            "@aws-sdk/middleware-recursion-detection": "3.272.0",
-            "@aws-sdk/middleware-retry": "3.272.0",
-            "@aws-sdk/middleware-sdk-sts": "3.272.0",
-            "@aws-sdk/middleware-serde": "3.272.0",
-            "@aws-sdk/middleware-signing": "3.272.0",
-            "@aws-sdk/middleware-stack": "3.272.0",
-            "@aws-sdk/middleware-user-agent": "3.272.0",
-            "@aws-sdk/node-config-provider": "3.272.0",
-            "@aws-sdk/node-http-handler": "3.272.0",
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/smithy-client": "3.279.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/url-parser": "3.272.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-            "@aws-sdk/util-defaults-mode-node": "3.279.0",
-            "@aws-sdk/util-endpoints": "3.272.0",
-            "@aws-sdk/util-retry": "3.272.0",
-            "@aws-sdk/util-user-agent-browser": "3.272.0",
-            "@aws-sdk/util-user-agent-node": "3.272.0",
-            "@aws-sdk/util-utf8": "3.254.0",
+            "@aws-sdk/config-resolver": "3.310.0",
+            "@aws-sdk/credential-provider-node": "3.319.0",
+            "@aws-sdk/fetch-http-handler": "3.310.0",
+            "@aws-sdk/hash-node": "3.310.0",
+            "@aws-sdk/invalid-dependency": "3.310.0",
+            "@aws-sdk/middleware-content-length": "3.310.0",
+            "@aws-sdk/middleware-endpoint": "3.310.0",
+            "@aws-sdk/middleware-host-header": "3.310.0",
+            "@aws-sdk/middleware-logger": "3.310.0",
+            "@aws-sdk/middleware-recursion-detection": "3.310.0",
+            "@aws-sdk/middleware-retry": "3.310.0",
+            "@aws-sdk/middleware-sdk-sts": "3.310.0",
+            "@aws-sdk/middleware-serde": "3.310.0",
+            "@aws-sdk/middleware-signing": "3.310.0",
+            "@aws-sdk/middleware-stack": "3.310.0",
+            "@aws-sdk/middleware-user-agent": "3.319.0",
+            "@aws-sdk/node-config-provider": "3.310.0",
+            "@aws-sdk/node-http-handler": "3.310.0",
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/smithy-client": "3.316.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/url-parser": "3.310.0",
+            "@aws-sdk/util-base64": "3.310.0",
+            "@aws-sdk/util-body-length-browser": "3.310.0",
+            "@aws-sdk/util-body-length-node": "3.310.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+            "@aws-sdk/util-defaults-mode-node": "3.316.0",
+            "@aws-sdk/util-endpoints": "3.319.0",
+            "@aws-sdk/util-retry": "3.310.0",
+            "@aws-sdk/util-user-agent-browser": "3.310.0",
+            "@aws-sdk/util-user-agent-node": "3.310.0",
+            "@aws-sdk/util-utf8": "3.310.0",
             "fast-xml-parser": "4.1.2",
-            "tslib": "^2.3.1"
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/config-resolver": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.272.0.tgz",
-          "integrity": "sha512-Dr4CffRVNsOp3LRNdpvcH6XuSgXOSLblWliCy/5I86cNl567KVMxujVx6uPrdTXYs2h1rt3MNl6jQGnAiJeTbw==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.310.0.tgz",
+          "integrity": "sha512-8vsT+/50lOqfDxka9m/rRt6oxv1WuGZoP8oPMk0Dt+TxXMbAzf4+rejBgiB96wshI1k3gLokYRjSQZn+dDtT8g==",
           "requires": {
-            "@aws-sdk/signature-v4": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/util-config-provider": "3.208.0",
-            "@aws-sdk/util-middleware": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-config-provider": "3.310.0",
+            "@aws-sdk/util-middleware": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/credential-provider-env": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.272.0.tgz",
-          "integrity": "sha512-QI65NbLnKLYHyTYhXaaUrq6eVsCCrMUb05WDA7+TJkWkjXesovpjc8vUKgFiLSxmgKmb2uOhHNcDyObKMrYQFw==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.310.0.tgz",
+          "integrity": "sha512-vvIPQpI16fj95xwS7M3D48F7QhZJBnnCgB5lR+b7So+vsG9ibm1mZRVGzVpdxCvgyOhHFbvrby9aalNJmmIP1A==",
           "requires": {
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/credential-provider-imds": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.272.0.tgz",
-          "integrity": "sha512-wwAfVY1jTFQEfxVfdYD5r5ieYGl+0g4nhekVxNMqE8E1JeRDd18OqiwAflzpgBIqxfqvCUkf+vl5JYyacMkNAQ==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.310.0.tgz",
+          "integrity": "sha512-baxK7Zp6dai5AGW01FIW27xS2KAaPUmKLIXv5SvFYsUgXXvNW55im4uG3b+2gA0F7V+hXvVBH08OEqmwW6we5w==",
           "requires": {
-            "@aws-sdk/node-config-provider": "3.272.0",
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/url-parser": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/node-config-provider": "3.310.0",
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/url-parser": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/credential-provider-ini": {
-          "version": "3.281.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.281.0.tgz",
-          "integrity": "sha512-H99nhMhHImQKgNhHKYc6usTS6UK8KzCcVGpILLVTuP97YlrYAMFAVstA3Xk6mZ28JAbHVXvI6vJjkMNOzCSKCA==",
+          "version": "3.319.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.319.0.tgz",
+          "integrity": "sha512-pzx388Fw1KlSgmIMUyRY8DJVYM3aXpwzjprD4RiQVPJeAI+t7oQmEvd2FiUZEuHDjWXcuonxgU+dk7i7HUk/HQ==",
           "requires": {
-            "@aws-sdk/credential-provider-env": "3.272.0",
-            "@aws-sdk/credential-provider-imds": "3.272.0",
-            "@aws-sdk/credential-provider-process": "3.272.0",
-            "@aws-sdk/credential-provider-sso": "3.281.0",
-            "@aws-sdk/credential-provider-web-identity": "3.272.0",
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/shared-ini-file-loader": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/credential-provider-env": "3.310.0",
+            "@aws-sdk/credential-provider-imds": "3.310.0",
+            "@aws-sdk/credential-provider-process": "3.310.0",
+            "@aws-sdk/credential-provider-sso": "3.319.0",
+            "@aws-sdk/credential-provider-web-identity": "3.310.0",
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/shared-ini-file-loader": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/credential-provider-node": {
-          "version": "3.281.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.281.0.tgz",
-          "integrity": "sha512-jhddd+lJp8G8hBJ+6glmXjfWJT3nxiE1aliH3fBC4RR3D+1kRXc99Xg6mbUb8bm+GrVZ4gzfiqSgg+ByKjd7xA==",
+          "version": "3.319.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.319.0.tgz",
+          "integrity": "sha512-DS4a0Rdd7ZtMshoeE+zuSgbC05YBcdzd0h89u/eX+1Yqx+HCjeb8WXkbXsz0Mwx8q9TE04aS8f6Bw9J4x4mO5g==",
           "requires": {
-            "@aws-sdk/credential-provider-env": "3.272.0",
-            "@aws-sdk/credential-provider-imds": "3.272.0",
-            "@aws-sdk/credential-provider-ini": "3.281.0",
-            "@aws-sdk/credential-provider-process": "3.272.0",
-            "@aws-sdk/credential-provider-sso": "3.281.0",
-            "@aws-sdk/credential-provider-web-identity": "3.272.0",
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/shared-ini-file-loader": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/credential-provider-env": "3.310.0",
+            "@aws-sdk/credential-provider-imds": "3.310.0",
+            "@aws-sdk/credential-provider-ini": "3.319.0",
+            "@aws-sdk/credential-provider-process": "3.310.0",
+            "@aws-sdk/credential-provider-sso": "3.319.0",
+            "@aws-sdk/credential-provider-web-identity": "3.310.0",
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/shared-ini-file-loader": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/credential-provider-process": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.272.0.tgz",
-          "integrity": "sha512-hiCAjWWm2PeBFp5cjkxqyam/XADjiS+e7GzwC34TbZn3LisS0uoweLojj9tD11NnnUhyhbLteUvu5+rotOLwrg==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.310.0.tgz",
+          "integrity": "sha512-h73sg6GPMUWC+3zMCbA1nZ2O03nNJt7G96JdmnantiXBwHpRKWW8nBTLzx5uhXn6hTuTaoQRP/P+oxQJKYdMmA==",
           "requires": {
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/shared-ini-file-loader": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/shared-ini-file-loader": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/credential-provider-sso": {
-          "version": "3.281.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.281.0.tgz",
-          "integrity": "sha512-IqJnpXuLpJYoSCf/Rt66/CPVTjfkam3z9+ZvlQJV+VbK+vGj276qEtTmSN3XPZZgF1XbWptvkzIWDszLhHiZmg==",
+          "version": "3.319.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.319.0.tgz",
+          "integrity": "sha512-gAUnWH41lxkIbANXu+Rz5zS0Iavjjmpf3C56vAMT7oaYZ3Cg/Ys5l2SwAucQGOCA2DdS2hDiSI8E+Yhr4F5toA==",
           "requires": {
-            "@aws-sdk/client-sso": "3.281.0",
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/shared-ini-file-loader": "3.272.0",
-            "@aws-sdk/token-providers": "3.281.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/client-sso": "3.319.0",
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/shared-ini-file-loader": "3.310.0",
+            "@aws-sdk/token-providers": "3.319.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/credential-provider-web-identity": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.272.0.tgz",
-          "integrity": "sha512-ImrHMkcgneGa/HadHAQXPwOrX26sAKuB8qlMxZF/ZCM2B55u8deY+ZVkVuraeKb7YsahMGehPFOfRAF6mvFI5Q==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.310.0.tgz",
+          "integrity": "sha512-H4SzuZXILNhK6/IR1uVvsUDZvzc051hem7GLyYghBCu8mU+tq28YhKE8MfSroi6eL2e5Vujloij1OM2EQQkPkw==",
           "requires": {
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/fetch-http-handler": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.272.0.tgz",
-          "integrity": "sha512-1Qhm9e0RbS1Xf4CZqUbQyUMkDLd7GrsRXWIvm9b86/vgeV8/WnjO3CMue9D51nYgcyQORhYXv6uVjAYCWbUExA==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.310.0.tgz",
+          "integrity": "sha512-Bi9vIwzdkw1zMcvi/zGzlWS9KfIEnAq4NNhsnCxbQ4OoIRU9wvU+WGZdBBhxg0ZxZmpp1j1aZhU53lLjA07MHw==",
           "requires": {
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/querystring-builder": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/querystring-builder": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-base64": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/hash-node": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.272.0.tgz",
-          "integrity": "sha512-40dwND+iAm3VtPHPZu7/+CIdVJFk2s0cWZt1lOiMPMSXycSYJ45wMk7Lly3uoqRx0uWfFK5iT2OCv+fJi5jTng==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.310.0.tgz",
+          "integrity": "sha512-NvE2fhRc8GRwCXBfDehxVAWCmVwVMILliAKVPAEr4yz2CkYs0tqU51S48x23dtna07H4qHtgpeNqVTthcIQOEQ==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/util-buffer-from": "3.208.0",
-            "@aws-sdk/util-utf8": "3.254.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-buffer-from": "3.310.0",
+            "@aws-sdk/util-utf8": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/invalid-dependency": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.272.0.tgz",
-          "integrity": "sha512-ysW6wbjl1Y78txHUQ/Tldj2Rg1BI7rpMO9B9xAF6yAX3mQ7t6SUPQG/ewOGvH2208NBIl3qP5e/hDf0Q6r/1iw==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.310.0.tgz",
+          "integrity": "sha512-1s5RG5rSPXoa/aZ/Kqr5U/7lqpx+Ry81GprQ2bxWqJvWQIJ0IRUwo5pk8XFxbKVr/2a+4lZT/c3OGoBOM1yRRA==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
+          "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
+          "requires": {
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/middleware-content-length": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.272.0.tgz",
-          "integrity": "sha512-sAbDZSTNmLX+UTGwlUHJBWy0QGQkiClpHwVFXACon+aG0ySLNeRKEVYs6NCPYldw4cj6hveLUn50cX44ukHErw==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.310.0.tgz",
+          "integrity": "sha512-P8tQZxgDt6CAh1wd/W6WPzjc+uWPJwQkm+F7rAwRlM+k9q17HrhnksGDKcpuuLyIhPQYdmOMIkpKVgXGa4avhQ==",
           "requires": {
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/middleware-endpoint": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.272.0.tgz",
-          "integrity": "sha512-Dk3JVjj7SxxoUKv3xGiOeBksvPtFhTDrVW75XJ98Ymv8gJH5L1sq4hIeJAHRKogGiRFq2J73mnZSlM9FVXEylg==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.310.0.tgz",
+          "integrity": "sha512-Z+N2vOL8K354/lstkClxLLsr6hCpVRh+0tCMXrVj66/NtKysCEZ/0b9LmqOwD9pWHNiI2mJqXwY0gxNlKAroUg==",
           "requires": {
-            "@aws-sdk/middleware-serde": "3.272.0",
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/signature-v4": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/url-parser": "3.272.0",
-            "@aws-sdk/util-config-provider": "3.208.0",
-            "@aws-sdk/util-middleware": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/middleware-serde": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/url-parser": "3.310.0",
+            "@aws-sdk/util-middleware": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/middleware-host-header": {
-          "version": "3.278.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.278.0.tgz",
-          "integrity": "sha512-oTkF3exy89KE8NgSeXFwD+0H0GRKL2qUw92t3caEj7+4KzU/0m3t7NtKlq2NLRtTJhZ/izYRpV536oogLzGm3g==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.310.0.tgz",
+          "integrity": "sha512-QWSA+46/hXorXyWa61ic2K7qZzwHTiwfk2e9mRRjeIRepUgI3qxFjsYqrWtrOGBjmFmq0pYIY8Bb/DCJuQqcoA==",
           "requires": {
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/middleware-logger": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.272.0.tgz",
-          "integrity": "sha512-u2SQ0hWrFwxbxxYMG5uMEgf01pQY5jauK/LYWgGIvuCmFgiyRQQP3oN7kkmsxnS9MWmNmhbyQguX2NY02s5e9w==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.310.0.tgz",
+          "integrity": "sha512-Lurm8XofrASBRnAVtiSNuDSRsRqPNg27RIFLLsLp/pqog9nFJ0vz0kgdb9S5Z+zw83Mm+UlqOe6D8NTUNp4fVg==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/middleware-recursion-detection": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.272.0.tgz",
-          "integrity": "sha512-Gp/eKWeUWVNiiBdmUM2qLkBv+VLSJKoWAO+aKmyxxwjjmWhE0FrfA1NQ1a3g+NGMhRbAfQdaYswRAKsul70ISg==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.310.0.tgz",
+          "integrity": "sha512-SuB75/xk/gyue24gkriTwO2jFd7YcUGZDClQYuRejgbXSa3CO0lWyawQtfLcSSEBp9izrEVXuFH24K1eAft5nQ==",
           "requires": {
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/middleware-retry": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.272.0.tgz",
-          "integrity": "sha512-pCGvHM7C76VbO/dFerH+Vwf7tGv7j+e+eGrvhQ35mRghCtfIou/WMfTZlD1TNee93crrAQQVZKjtW3dMB3WCzg==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.310.0.tgz",
+          "integrity": "sha512-oTPsRy2W4s+dfxbJPW7Km+hHtv/OMsNsVfThAq8DDYKC13qlr1aAyOqGLD+dpBy2aKe7ss517Sy2HcHtHqm7/g==",
           "requires": {
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/service-error-classification": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/util-middleware": "3.272.0",
-            "@aws-sdk/util-retry": "3.272.0",
-            "tslib": "^2.3.1",
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/service-error-classification": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-middleware": "3.310.0",
+            "@aws-sdk/util-retry": "3.310.0",
+            "tslib": "^2.5.0",
             "uuid": "^8.3.2"
           }
         },
         "@aws-sdk/middleware-sdk-sts": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.272.0.tgz",
-          "integrity": "sha512-VvYPg7LrDIjUOWueSzo2wBzcNG7dw+cmzV6zAKaLxf0RC5jeAP4hE0OzDiiZfDrjNghEzgq/V+0NO+LewqYL9Q==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.310.0.tgz",
+          "integrity": "sha512-+5PFwlYNLvLLIfw0ASAoWV/iIF8Zv6R6QGtyP0CclhRSvNjgbQDVnV0g95MC5qvh+GB/Yjlkt8qAjLSPjHfsrQ==",
           "requires": {
-            "@aws-sdk/middleware-signing": "3.272.0",
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/signature-v4": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/middleware-signing": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/middleware-serde": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.272.0.tgz",
-          "integrity": "sha512-kW1uOxgPSwtXPB5rm3QLdWomu42lkYpQL94tM1BjyFOWmBLO2lQhk5a7Dw6HkTozT9a+vxtscLChRa6KZe61Hw==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.310.0.tgz",
+          "integrity": "sha512-RNeeTVWSLTaentUeCgQKZhAl+C6hxtwD78cQWS10UymWpQFwbaxztzKUu4UQS5xA2j6PxwPRRUjqa4jcFjfLsg==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/middleware-signing": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.272.0.tgz",
-          "integrity": "sha512-4LChFK4VAR91X+dupqM8fQqYhFGE0G4Bf9rQlVTgGSbi2KUOmpqXzH0/WKE228nKuEhmH8+Qd2VPSAE2JcyAUA==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.310.0.tgz",
+          "integrity": "sha512-f9mKq+XMdW207Af3hKjdTnpNhdtwqWuvFs/ZyXoOkp/g1MY1O6L23Jy6i52m29LxbT4AuNRG1oKODfXM0vYVjQ==",
           "requires": {
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/signature-v4": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/util-middleware": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/signature-v4": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-middleware": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/middleware-stack": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.272.0.tgz",
-          "integrity": "sha512-jhwhknnPBGhfXAGV5GXUWfEhDFoP/DN8MPCO2yC5OAxyp6oVJ8lTPLkZYMTW5VL0c0eG44dXpF4Ib01V+PlDrQ==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.310.0.tgz",
+          "integrity": "sha512-010O1PD+UAcZVKRvqEusE1KJqN96wwrf6QsqbRM0ywsKQ21NDweaHvEDlds2VHpgmofxkRLRu/IDrlPkKRQrRg==",
           "requires": {
-            "tslib": "^2.3.1"
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/middleware-user-agent": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.272.0.tgz",
-          "integrity": "sha512-Qy7/0fsDJxY5l0bEk7WKDfqb4Os/sCAgFR2zEvrhDtbkhYPf72ysvg/nRUTncmCbo8tOok4SJii2myk8KMfjjw==",
+          "version": "3.319.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.319.0.tgz",
+          "integrity": "sha512-ytaLx2dlR5AdMSne6FuDCISVg8hjyKj+cHU20b2CRA/E/z+XXrLrssp4JrCgizRKPPUep0psMIa22Zd6osTT5Q==",
           "requires": {
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-endpoints": "3.319.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/node-config-provider": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.272.0.tgz",
-          "integrity": "sha512-YYCIBh9g1EQo7hm2l22HX5Yr9RoPQ2RCvhzKvF1n1e8t1QH4iObQrYUtqHG4khcm64Cft8C5MwZmgzHbya5Z6Q==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.310.0.tgz",
+          "integrity": "sha512-T/Pp6htc6hq/Cq+MLNDSyiwWCMVF6GqbBbXKVlO5L8rdHx4sq9xPdoPveZhGWrxvkanjA6eCwUp6E0riBOSVng==",
           "requires": {
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/shared-ini-file-loader": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/shared-ini-file-loader": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/node-http-handler": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.272.0.tgz",
-          "integrity": "sha512-VrW9PjhhngeyYp4yGYPe5S0vgZH6NwU3Po9xAgayUeE37Inr7LS1YteFMHdpgsUUeNXnh7d06CXqHo1XjtqOKA==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.310.0.tgz",
+          "integrity": "sha512-irv9mbcM9xC2xYjArQF5SYmHBMu4ciMWtGsoHII1nRuFOl9FoT4ffTvEPuLlfC6pznzvKt9zvnm6xXj7gDChKg==",
           "requires": {
-            "@aws-sdk/abort-controller": "3.272.0",
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/querystring-builder": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/abort-controller": "3.310.0",
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/querystring-builder": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/property-provider": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.272.0.tgz",
-          "integrity": "sha512-V1pZTaH5eqpAt8O8CzbItHhOtzIfFuWymvwZFkAtwKuaHpnl7jjrTouV482zoq8AD/fF+VVSshwBKYA7bhidIw==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.310.0.tgz",
+          "integrity": "sha512-3lxDb0akV6BBzmFe4nLPaoliQbAifyWJhuvuDOu7e8NzouvpQXs0275w9LePhhcgjKAEVXUIse05ZW2DLbxo/g==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/protocol-http": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.272.0.tgz",
-          "integrity": "sha512-4JQ54v5Yn08jspNDeHo45CaSn1CvTJqS1Ywgr79eU6jBExtguOWv6LNtwVSBD9X37v88iqaxt8iu1Z3pZZAJeg==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.310.0.tgz",
+          "integrity": "sha512-fgZ1aw/irQtnrsR58pS8ThKOWo57Py3xX6giRvwSgZDEcxHfVzuQjy9yPuV++v04fdmdtgpbGf8WfvAAJ11yXQ==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/querystring-builder": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.272.0.tgz",
-          "integrity": "sha512-ndo++7GkdCj5tBXE6rGcITpSpZS4PfyV38wntGYAlj9liL1omk3bLZRY6uzqqkJpVHqbg2fD7O2qHNItzZgqhw==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.310.0.tgz",
+          "integrity": "sha512-ZHH8GV/80+pWGo7DzsvwvXR5xVxUHXUvPJPFAkhr6nCf78igdoF8gR10ScFoEKbtEapoNTaZlKHPXxpD8aPG7A==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/util-uri-escape": "3.201.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-uri-escape": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/querystring-parser": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.272.0.tgz",
-          "integrity": "sha512-5oS4/9n6N1LZW9tI3qq/0GnCuWoOXRgcHVB+AJLRBvDbEe+GI+C/xK1tKLsfpDNgsQJHc4IPQoIt4megyZ/1+A==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.310.0.tgz",
+          "integrity": "sha512-YkIznoP6lsiIUHinx++/lbb3tlMURGGqMpo0Pnn32zYzGrJXA6eC3D0as2EcMjo55onTfuLcIiX4qzXes2MYOA==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/service-error-classification": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.272.0.tgz",
-          "integrity": "sha512-REoltM1LK9byyIufLqx9znhSolPcHQgVHIA2S0zu5sdt5qER4OubkLAXuo4MBbisUTmh8VOOvIyUb5ijZCXq1w=="
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.310.0.tgz",
+          "integrity": "sha512-PuyC7k3qfIKeH2LCnDwbttMOKq3qAx4buvg0yfnJtQOz6t1AR8gsnAq0CjKXXyfkXwNKWTqCpE6lVNUIkXgsMw=="
         },
         "@aws-sdk/shared-ini-file-loader": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.272.0.tgz",
-          "integrity": "sha512-lzFPohp5sy2XvwFjZIzLVCRpC0i5cwBiaXmFzXYQZJm6FSCszHO4ax+m9yrtlyVFF/2YPWl+/bzNthy4aJtseA==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.310.0.tgz",
+          "integrity": "sha512-N0q9pG0xSjQwc690YQND5bofm+4nfUviQ/Ppgan2kU6aU0WUq8KwgHJBto/YEEI+VlrME30jZJnxtOvcZJc2XA==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/signature-v4": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.272.0.tgz",
-          "integrity": "sha512-pWxnHG1NqJWMwlhJ6NHNiUikOL00DHROmxah6krJPMPq4I3am2KY2Rs/8ouWhnEXKaHAv4EQhSALJ+7Mq5S4/A==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.310.0.tgz",
+          "integrity": "sha512-1M60P1ZBNAjCFv9sYW29OF6okktaeibWyW3lMXqzoHF70lHBZh+838iUchznXUA5FLabfn4jBFWMRxlAXJUY2Q==",
           "requires": {
-            "@aws-sdk/is-array-buffer": "3.201.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/util-hex-encoding": "3.201.0",
-            "@aws-sdk/util-middleware": "3.272.0",
-            "@aws-sdk/util-uri-escape": "3.201.0",
-            "@aws-sdk/util-utf8": "3.254.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/is-array-buffer": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-hex-encoding": "3.310.0",
+            "@aws-sdk/util-middleware": "3.310.0",
+            "@aws-sdk/util-uri-escape": "3.310.0",
+            "@aws-sdk/util-utf8": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/smithy-client": {
-          "version": "3.279.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.279.0.tgz",
-          "integrity": "sha512-ZcYWUQDGAYN6NXRpJuSn46PetrpPCA6TrDVwP9+3pERzTXZ66npXoG2XhHjNrOXy/Ted5A3OxKrM4/zLu9tK3A==",
+          "version": "3.316.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.316.0.tgz",
+          "integrity": "sha512-6YXOKbRnXeS8r8RWzuL6JMBolDYM5Wa4fD/VY6x/wK78i2xErHOvqzHgyyeLI1MMw4uqyd4wRNJNWC9TMPduXw==",
           "requires": {
-            "@aws-sdk/middleware-stack": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/middleware-stack": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/token-providers": {
-          "version": "3.281.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.281.0.tgz",
-          "integrity": "sha512-36Vg/F6Edm7qdjcTeNVON+sK2edgHhmhTtAEjWcuUk5AX/Et+Ate/A2N8HD3nxwlAcgidfnBC9SHYJatbhcEnQ==",
+          "version": "3.319.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.319.0.tgz",
+          "integrity": "sha512-5utg6VL6Pl0uiLUn8ZJPYYxzCb9VRPsgJmGXktRUwq0YlTJ6ABcaxTXwZcC++sjh/qyCQDK5PPLNU5kIBttHMQ==",
           "requires": {
-            "@aws-sdk/client-sso-oidc": "3.281.0",
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/shared-ini-file-loader": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/client-sso-oidc": "3.319.0",
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/shared-ini-file-loader": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/types": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.272.0.tgz",
-          "integrity": "sha512-MmmL6vxMGP5Bsi+4wRx4mxYlU/LX6M0noOXrDh/x5FfG7/4ZOar/nDxqDadhJtNM88cuWVHZWY59P54JzkGWmA==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.310.0.tgz",
+          "integrity": "sha512-j8eamQJ7YcIhw7fneUfs8LYl3t01k4uHi4ZDmNRgtbmbmTTG3FZc2MotStZnp3nZB6vLiPF1o5aoJxWVvkzS6A==",
           "requires": {
-            "tslib": "^2.3.1"
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/url-parser": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.272.0.tgz",
-          "integrity": "sha512-vX/Tx02PlnQ/Kgtf5TnrNDHPNbY+amLZjW0Z1d9vzAvSZhQ4i9Y18yxoRDIaDTCNVRDjdhV8iuctW+05PB5JtQ==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.310.0.tgz",
+          "integrity": "sha512-mCLnCaSB9rQvAgx33u0DujLvr4d5yEm/W5r789GblwwQnlNXedVu50QRizMLTpltYWyAUoXjJgQnJHmJMaKXhw==",
           "requires": {
-            "@aws-sdk/querystring-parser": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/querystring-parser": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-base64": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
+          "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-body-length-browser": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
+          "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
+          "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
+          "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-config-provider": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
+          "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
+          "requires": {
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/util-defaults-mode-browser": {
-          "version": "3.279.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.279.0.tgz",
-          "integrity": "sha512-RnchYRrpapTT5Hu23LOfk6e8RMVq0kUzho6xA6TJj1a4uGxkcRMvgzPipCq1P5uHu0mrkQBg9pGPEVNOUs38/Q==",
+          "version": "3.316.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.316.0.tgz",
+          "integrity": "sha512-6FSqLhYmaihtH2n1s4b2rlLW0ABU8N6VZIfzLfe2ING4PF0MzfaMMhnTFUHVXfKCVGoR8yP6iyFTRCyHGVEL1w==",
           "requires": {
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
             "bowser": "^2.11.0",
-            "tslib": "^2.3.1"
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/util-defaults-mode-node": {
-          "version": "3.279.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.279.0.tgz",
-          "integrity": "sha512-A2NB10xReWC+GSnOivKGZ9rnljIZdEP8WMCQQEnA6DJNI19AUFF/O9QJ9y+cHGLKEms7jH86Y99wShdpzAK+Jw==",
+          "version": "3.316.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.316.0.tgz",
+          "integrity": "sha512-dkYy10hdjPSScXXvnjGpZpnJxllkb6ICHgLMwZ4JczLHhPM12T/4PQ758YN8HS+muiYDGX1Bl2z1jd/bMcewBQ==",
           "requires": {
-            "@aws-sdk/config-resolver": "3.272.0",
-            "@aws-sdk/credential-provider-imds": "3.272.0",
-            "@aws-sdk/node-config-provider": "3.272.0",
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/config-resolver": "3.310.0",
+            "@aws-sdk/credential-provider-imds": "3.310.0",
+            "@aws-sdk/node-config-provider": "3.310.0",
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/util-endpoints": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.272.0.tgz",
-          "integrity": "sha512-c4MPUaJt2G6gGpoiwIOqDfUa98c1J63RpYvf/spQEKOtC/tF5Gfqlxuq8FnAl5lHnrqj1B9ZXLLxFhHtDR0IiQ==",
+          "version": "3.319.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.319.0.tgz",
+          "integrity": "sha512-3I64UMoYA2e2++oOUJXRcFtYLpLylnZFRltWfPo1B3dLlf+MIWat9djT+mMus+hW1ntLsvAIVu1hLVePJC0gvw==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
+          "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
+          "requires": {
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/util-middleware": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.272.0.tgz",
-          "integrity": "sha512-Abw8m30arbwxqmeMMha5J11ESpHUNmCeSqSzE8/C4B8jZQtHY4kq7f+upzcNIQ11lsd+uzBEzNG3+dDRi0XOJQ==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.310.0.tgz",
+          "integrity": "sha512-FTSUKL/eRb9X6uEZClrTe27QFXUNNp7fxYrPndZwk1hlaOP5ix+MIHBcI7pIiiY/JPfOUmPyZOu+HetlFXjWog==",
           "requires": {
-            "tslib": "^2.3.1"
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/util-retry": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.272.0.tgz",
-          "integrity": "sha512-Ngha5414LR4gRHURVKC9ZYXsEJhMkm+SJ+44wlzOhavglfdcKKPUsibz5cKY1jpUV7oKECwaxHWpBB8r6h+hOg==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.310.0.tgz",
+          "integrity": "sha512-FwWGhCBLfoivTMUHu1LIn4NjrN9JLJ/aX5aZmbcPIOhZVFJj638j0qDgZXyfvVqBuBZh7M8kGq0Oahy3dp69OA==",
           "requires": {
-            "@aws-sdk/service-error-classification": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/service-error-classification": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
+          "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
+          "requires": {
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/util-user-agent-browser": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.272.0.tgz",
-          "integrity": "sha512-Lp5QX5bH6uuwBlIdr7w7OAcAI50ttyskb++yUr9i+SPvj6RI2dsfIBaK4mDg1qUdM5LeUdvIyqwj3XHjFKAAvA==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.310.0.tgz",
+          "integrity": "sha512-yU/4QnHHuQ5z3vsUqMQVfYLbZGYwpYblPiuZx4Zo9+x0PBkNjYMqctdDcrpoH9Z2xZiDN16AmQGK1tix117ZKw==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
+            "@aws-sdk/types": "3.310.0",
             "bowser": "^2.11.0",
-            "tslib": "^2.3.1"
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/util-user-agent-node": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.272.0.tgz",
-          "integrity": "sha512-ljK+R3l+Q1LIHrcR+Knhk0rmcSkfFadZ8V+crEGpABf/QUQRg7NkZMsoe814tfBO5F7tMxo8wwwSdaVNNHtoRA==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.310.0.tgz",
+          "integrity": "sha512-Ra3pEl+Gn2BpeE7KiDGpi4zj7WJXZA5GXnGo3mjbi9+Y3zrbuhJAbdZO3mO/o7xDgMC6ph4xCTbaSGzU6b6EDg==",
           "requires": {
-            "@aws-sdk/node-config-provider": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/node-config-provider": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "fast-xml-parser": {
@@ -21617,6 +22269,15 @@
             "tslib": "^2.3.1"
           }
         },
+        "@aws-sdk/util-utf8": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.254.0.tgz",
+          "integrity": "sha512-14Kso/eIt5/qfIBmhEL9L1IfyUqswjSTqO2mY7KOzUZ9SZbwn3rpxmtkhmATkRjD7XIlLKaxBkI7tU9Zjzj8Kw==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
         "fast-xml-parser": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
@@ -21628,47 +22289,47 @@
       }
     },
     "@aws-sdk/client-kinesis-video-archived-media": {
-      "version": "3.281.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kinesis-video-archived-media/-/client-kinesis-video-archived-media-3.281.0.tgz",
-      "integrity": "sha512-3jUDDhq1vglYXb41uTxFOgysAsKEc0rpI2craXpXyEvpiRm7NGBKWHxgCOZMsX9ivbWESQAXNL82gNMpkiduFg==",
+      "version": "3.321.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kinesis-video-archived-media/-/client-kinesis-video-archived-media-3.321.1.tgz",
+      "integrity": "sha512-HBHEvwYDGi4tH/Ya2mD2ztZVRLsq4qWQFYmS4ONWFuupt2oOxbyaVVvqoO9hC5Yv+HF38YvM6pRKwBMmJvMqhw==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.281.0",
-        "@aws-sdk/config-resolver": "3.272.0",
-        "@aws-sdk/credential-provider-node": "3.281.0",
-        "@aws-sdk/fetch-http-handler": "3.272.0",
-        "@aws-sdk/hash-node": "3.272.0",
-        "@aws-sdk/invalid-dependency": "3.272.0",
-        "@aws-sdk/middleware-content-length": "3.272.0",
-        "@aws-sdk/middleware-endpoint": "3.272.0",
-        "@aws-sdk/middleware-host-header": "3.278.0",
-        "@aws-sdk/middleware-logger": "3.272.0",
-        "@aws-sdk/middleware-recursion-detection": "3.272.0",
-        "@aws-sdk/middleware-retry": "3.272.0",
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/middleware-signing": "3.272.0",
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/middleware-user-agent": "3.272.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/node-http-handler": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/smithy-client": "3.279.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-        "@aws-sdk/util-defaults-mode-node": "3.279.0",
-        "@aws-sdk/util-endpoints": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "@aws-sdk/util-stream-browser": "3.272.0",
-        "@aws-sdk/util-stream-node": "3.272.0",
-        "@aws-sdk/util-user-agent-browser": "3.272.0",
-        "@aws-sdk/util-user-agent-node": "3.272.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/client-sts": "3.321.1",
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/credential-provider-node": "3.321.1",
+        "@aws-sdk/fetch-http-handler": "3.310.0",
+        "@aws-sdk/hash-node": "3.310.0",
+        "@aws-sdk/invalid-dependency": "3.310.0",
+        "@aws-sdk/middleware-content-length": "3.310.0",
+        "@aws-sdk/middleware-endpoint": "3.310.0",
+        "@aws-sdk/middleware-host-header": "3.310.0",
+        "@aws-sdk/middleware-logger": "3.310.0",
+        "@aws-sdk/middleware-recursion-detection": "3.310.0",
+        "@aws-sdk/middleware-retry": "3.310.0",
+        "@aws-sdk/middleware-serde": "3.310.0",
+        "@aws-sdk/middleware-signing": "3.310.0",
+        "@aws-sdk/middleware-stack": "3.310.0",
+        "@aws-sdk/middleware-user-agent": "3.319.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/node-http-handler": "3.321.1",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/smithy-client": "3.316.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+        "@aws-sdk/util-defaults-mode-node": "3.316.0",
+        "@aws-sdk/util-endpoints": "3.319.0",
+        "@aws-sdk/util-retry": "3.310.0",
+        "@aws-sdk/util-stream-browser": "3.310.0",
+        "@aws-sdk/util-stream-node": "3.321.1",
+        "@aws-sdk/util-user-agent-browser": "3.310.0",
+        "@aws-sdk/util-user-agent-node": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "dependencies": {
         "@aws-crypto/ie11-detection": {
@@ -21758,585 +22419,645 @@
           }
         },
         "@aws-sdk/abort-controller": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.272.0.tgz",
-          "integrity": "sha512-s2TV3phapcTwZNr4qLxbfuQuE9ZMP4RoJdkvRRCkKdm6jslsWLJf2Zlcxti/23hOlINUMYv2iXE2pftIgWGdpg==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.310.0.tgz",
+          "integrity": "sha512-v1zrRQxDLA1MdPim159Vx/CPHqsB4uybSxRi1CnfHO5ZjHryx3a5htW2gdGAykVCul40+yJXvfpufMrELVxH+g==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/client-sso": {
-          "version": "3.281.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.281.0.tgz",
-          "integrity": "sha512-3RvO5zClQhu37w9VMLoHPGk58S3y8Spb7XX8rW51bm5TUglYQskQ0X2VLEUW/7ZGx/peokHws9Z9+w5yGq5sdA==",
+          "version": "3.321.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.321.1.tgz",
+          "integrity": "sha512-ecoT4tBGtRJR5G7oLBTMXZmgZZlff1amhSdKPEtkWxv6kWc8VPb5rRuRgVPsDR9HuesI6ZVlODptvGtnfkIJwA==",
           "requires": {
             "@aws-crypto/sha256-browser": "3.0.0",
             "@aws-crypto/sha256-js": "3.0.0",
-            "@aws-sdk/config-resolver": "3.272.0",
-            "@aws-sdk/fetch-http-handler": "3.272.0",
-            "@aws-sdk/hash-node": "3.272.0",
-            "@aws-sdk/invalid-dependency": "3.272.0",
-            "@aws-sdk/middleware-content-length": "3.272.0",
-            "@aws-sdk/middleware-endpoint": "3.272.0",
-            "@aws-sdk/middleware-host-header": "3.278.0",
-            "@aws-sdk/middleware-logger": "3.272.0",
-            "@aws-sdk/middleware-recursion-detection": "3.272.0",
-            "@aws-sdk/middleware-retry": "3.272.0",
-            "@aws-sdk/middleware-serde": "3.272.0",
-            "@aws-sdk/middleware-stack": "3.272.0",
-            "@aws-sdk/middleware-user-agent": "3.272.0",
-            "@aws-sdk/node-config-provider": "3.272.0",
-            "@aws-sdk/node-http-handler": "3.272.0",
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/smithy-client": "3.279.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/url-parser": "3.272.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-            "@aws-sdk/util-defaults-mode-node": "3.279.0",
-            "@aws-sdk/util-endpoints": "3.272.0",
-            "@aws-sdk/util-retry": "3.272.0",
-            "@aws-sdk/util-user-agent-browser": "3.272.0",
-            "@aws-sdk/util-user-agent-node": "3.272.0",
-            "@aws-sdk/util-utf8": "3.254.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/config-resolver": "3.310.0",
+            "@aws-sdk/fetch-http-handler": "3.310.0",
+            "@aws-sdk/hash-node": "3.310.0",
+            "@aws-sdk/invalid-dependency": "3.310.0",
+            "@aws-sdk/middleware-content-length": "3.310.0",
+            "@aws-sdk/middleware-endpoint": "3.310.0",
+            "@aws-sdk/middleware-host-header": "3.310.0",
+            "@aws-sdk/middleware-logger": "3.310.0",
+            "@aws-sdk/middleware-recursion-detection": "3.310.0",
+            "@aws-sdk/middleware-retry": "3.310.0",
+            "@aws-sdk/middleware-serde": "3.310.0",
+            "@aws-sdk/middleware-stack": "3.310.0",
+            "@aws-sdk/middleware-user-agent": "3.319.0",
+            "@aws-sdk/node-config-provider": "3.310.0",
+            "@aws-sdk/node-http-handler": "3.321.1",
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/smithy-client": "3.316.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/url-parser": "3.310.0",
+            "@aws-sdk/util-base64": "3.310.0",
+            "@aws-sdk/util-body-length-browser": "3.310.0",
+            "@aws-sdk/util-body-length-node": "3.310.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+            "@aws-sdk/util-defaults-mode-node": "3.316.0",
+            "@aws-sdk/util-endpoints": "3.319.0",
+            "@aws-sdk/util-retry": "3.310.0",
+            "@aws-sdk/util-user-agent-browser": "3.310.0",
+            "@aws-sdk/util-user-agent-node": "3.310.0",
+            "@aws-sdk/util-utf8": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/client-sso-oidc": {
-          "version": "3.281.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.281.0.tgz",
-          "integrity": "sha512-P6zf9pDuxApVoCYStAg7L8BU9AcWI8PxfLSX4r2WnmcQropxzPJ3op1j9nvbwwBDMFWephijVY4AVp8MqPcPyg==",
+          "version": "3.321.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.321.1.tgz",
+          "integrity": "sha512-PBVfHQbyrsfzbnO6u9d9Sik8JlXGLhHj3zLd87iBkYXBdHwD5NuvwWu7OtjUtrHjP4SfzodVwfjmTbDAFqbtzw==",
           "requires": {
             "@aws-crypto/sha256-browser": "3.0.0",
             "@aws-crypto/sha256-js": "3.0.0",
-            "@aws-sdk/config-resolver": "3.272.0",
-            "@aws-sdk/fetch-http-handler": "3.272.0",
-            "@aws-sdk/hash-node": "3.272.0",
-            "@aws-sdk/invalid-dependency": "3.272.0",
-            "@aws-sdk/middleware-content-length": "3.272.0",
-            "@aws-sdk/middleware-endpoint": "3.272.0",
-            "@aws-sdk/middleware-host-header": "3.278.0",
-            "@aws-sdk/middleware-logger": "3.272.0",
-            "@aws-sdk/middleware-recursion-detection": "3.272.0",
-            "@aws-sdk/middleware-retry": "3.272.0",
-            "@aws-sdk/middleware-serde": "3.272.0",
-            "@aws-sdk/middleware-stack": "3.272.0",
-            "@aws-sdk/middleware-user-agent": "3.272.0",
-            "@aws-sdk/node-config-provider": "3.272.0",
-            "@aws-sdk/node-http-handler": "3.272.0",
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/smithy-client": "3.279.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/url-parser": "3.272.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-            "@aws-sdk/util-defaults-mode-node": "3.279.0",
-            "@aws-sdk/util-endpoints": "3.272.0",
-            "@aws-sdk/util-retry": "3.272.0",
-            "@aws-sdk/util-user-agent-browser": "3.272.0",
-            "@aws-sdk/util-user-agent-node": "3.272.0",
-            "@aws-sdk/util-utf8": "3.254.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/config-resolver": "3.310.0",
+            "@aws-sdk/fetch-http-handler": "3.310.0",
+            "@aws-sdk/hash-node": "3.310.0",
+            "@aws-sdk/invalid-dependency": "3.310.0",
+            "@aws-sdk/middleware-content-length": "3.310.0",
+            "@aws-sdk/middleware-endpoint": "3.310.0",
+            "@aws-sdk/middleware-host-header": "3.310.0",
+            "@aws-sdk/middleware-logger": "3.310.0",
+            "@aws-sdk/middleware-recursion-detection": "3.310.0",
+            "@aws-sdk/middleware-retry": "3.310.0",
+            "@aws-sdk/middleware-serde": "3.310.0",
+            "@aws-sdk/middleware-stack": "3.310.0",
+            "@aws-sdk/middleware-user-agent": "3.319.0",
+            "@aws-sdk/node-config-provider": "3.310.0",
+            "@aws-sdk/node-http-handler": "3.321.1",
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/smithy-client": "3.316.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/url-parser": "3.310.0",
+            "@aws-sdk/util-base64": "3.310.0",
+            "@aws-sdk/util-body-length-browser": "3.310.0",
+            "@aws-sdk/util-body-length-node": "3.310.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+            "@aws-sdk/util-defaults-mode-node": "3.316.0",
+            "@aws-sdk/util-endpoints": "3.319.0",
+            "@aws-sdk/util-retry": "3.310.0",
+            "@aws-sdk/util-user-agent-browser": "3.310.0",
+            "@aws-sdk/util-user-agent-node": "3.310.0",
+            "@aws-sdk/util-utf8": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/client-sts": {
-          "version": "3.281.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.281.0.tgz",
-          "integrity": "sha512-w8QomyhCVEArRcXgOkjbofiS/PLEKWRAyYBovjMS1cGhns2ZYJXFgHNgr3VGE54TghUc5dR1CqKuBKKM4ThrgA==",
+          "version": "3.321.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.321.1.tgz",
+          "integrity": "sha512-AB+N4a1TVEKl9Sd5O2TxTprEZp7Va6zPZLMraFAYMdmJVBmCmmwyBs7ygju685DpQ1dos5PRsKCRcossyY5pDQ==",
           "requires": {
             "@aws-crypto/sha256-browser": "3.0.0",
             "@aws-crypto/sha256-js": "3.0.0",
-            "@aws-sdk/config-resolver": "3.272.0",
-            "@aws-sdk/credential-provider-node": "3.281.0",
-            "@aws-sdk/fetch-http-handler": "3.272.0",
-            "@aws-sdk/hash-node": "3.272.0",
-            "@aws-sdk/invalid-dependency": "3.272.0",
-            "@aws-sdk/middleware-content-length": "3.272.0",
-            "@aws-sdk/middleware-endpoint": "3.272.0",
-            "@aws-sdk/middleware-host-header": "3.278.0",
-            "@aws-sdk/middleware-logger": "3.272.0",
-            "@aws-sdk/middleware-recursion-detection": "3.272.0",
-            "@aws-sdk/middleware-retry": "3.272.0",
-            "@aws-sdk/middleware-sdk-sts": "3.272.0",
-            "@aws-sdk/middleware-serde": "3.272.0",
-            "@aws-sdk/middleware-signing": "3.272.0",
-            "@aws-sdk/middleware-stack": "3.272.0",
-            "@aws-sdk/middleware-user-agent": "3.272.0",
-            "@aws-sdk/node-config-provider": "3.272.0",
-            "@aws-sdk/node-http-handler": "3.272.0",
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/smithy-client": "3.279.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/url-parser": "3.272.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-            "@aws-sdk/util-defaults-mode-node": "3.279.0",
-            "@aws-sdk/util-endpoints": "3.272.0",
-            "@aws-sdk/util-retry": "3.272.0",
-            "@aws-sdk/util-user-agent-browser": "3.272.0",
-            "@aws-sdk/util-user-agent-node": "3.272.0",
-            "@aws-sdk/util-utf8": "3.254.0",
+            "@aws-sdk/config-resolver": "3.310.0",
+            "@aws-sdk/credential-provider-node": "3.321.1",
+            "@aws-sdk/fetch-http-handler": "3.310.0",
+            "@aws-sdk/hash-node": "3.310.0",
+            "@aws-sdk/invalid-dependency": "3.310.0",
+            "@aws-sdk/middleware-content-length": "3.310.0",
+            "@aws-sdk/middleware-endpoint": "3.310.0",
+            "@aws-sdk/middleware-host-header": "3.310.0",
+            "@aws-sdk/middleware-logger": "3.310.0",
+            "@aws-sdk/middleware-recursion-detection": "3.310.0",
+            "@aws-sdk/middleware-retry": "3.310.0",
+            "@aws-sdk/middleware-sdk-sts": "3.310.0",
+            "@aws-sdk/middleware-serde": "3.310.0",
+            "@aws-sdk/middleware-signing": "3.310.0",
+            "@aws-sdk/middleware-stack": "3.310.0",
+            "@aws-sdk/middleware-user-agent": "3.319.0",
+            "@aws-sdk/node-config-provider": "3.310.0",
+            "@aws-sdk/node-http-handler": "3.321.1",
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/smithy-client": "3.316.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/url-parser": "3.310.0",
+            "@aws-sdk/util-base64": "3.310.0",
+            "@aws-sdk/util-body-length-browser": "3.310.0",
+            "@aws-sdk/util-body-length-node": "3.310.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+            "@aws-sdk/util-defaults-mode-node": "3.316.0",
+            "@aws-sdk/util-endpoints": "3.319.0",
+            "@aws-sdk/util-retry": "3.310.0",
+            "@aws-sdk/util-user-agent-browser": "3.310.0",
+            "@aws-sdk/util-user-agent-node": "3.310.0",
+            "@aws-sdk/util-utf8": "3.310.0",
             "fast-xml-parser": "4.1.2",
-            "tslib": "^2.3.1"
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/config-resolver": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.272.0.tgz",
-          "integrity": "sha512-Dr4CffRVNsOp3LRNdpvcH6XuSgXOSLblWliCy/5I86cNl567KVMxujVx6uPrdTXYs2h1rt3MNl6jQGnAiJeTbw==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.310.0.tgz",
+          "integrity": "sha512-8vsT+/50lOqfDxka9m/rRt6oxv1WuGZoP8oPMk0Dt+TxXMbAzf4+rejBgiB96wshI1k3gLokYRjSQZn+dDtT8g==",
           "requires": {
-            "@aws-sdk/signature-v4": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/util-config-provider": "3.208.0",
-            "@aws-sdk/util-middleware": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-config-provider": "3.310.0",
+            "@aws-sdk/util-middleware": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/credential-provider-env": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.272.0.tgz",
-          "integrity": "sha512-QI65NbLnKLYHyTYhXaaUrq6eVsCCrMUb05WDA7+TJkWkjXesovpjc8vUKgFiLSxmgKmb2uOhHNcDyObKMrYQFw==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.310.0.tgz",
+          "integrity": "sha512-vvIPQpI16fj95xwS7M3D48F7QhZJBnnCgB5lR+b7So+vsG9ibm1mZRVGzVpdxCvgyOhHFbvrby9aalNJmmIP1A==",
           "requires": {
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/credential-provider-imds": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.272.0.tgz",
-          "integrity": "sha512-wwAfVY1jTFQEfxVfdYD5r5ieYGl+0g4nhekVxNMqE8E1JeRDd18OqiwAflzpgBIqxfqvCUkf+vl5JYyacMkNAQ==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.310.0.tgz",
+          "integrity": "sha512-baxK7Zp6dai5AGW01FIW27xS2KAaPUmKLIXv5SvFYsUgXXvNW55im4uG3b+2gA0F7V+hXvVBH08OEqmwW6we5w==",
           "requires": {
-            "@aws-sdk/node-config-provider": "3.272.0",
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/url-parser": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/node-config-provider": "3.310.0",
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/url-parser": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/credential-provider-ini": {
-          "version": "3.281.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.281.0.tgz",
-          "integrity": "sha512-H99nhMhHImQKgNhHKYc6usTS6UK8KzCcVGpILLVTuP97YlrYAMFAVstA3Xk6mZ28JAbHVXvI6vJjkMNOzCSKCA==",
+          "version": "3.321.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.321.1.tgz",
+          "integrity": "sha512-prndSVQhiikNaI40bYnM2Q8PkC35FCwhbQnBk6KXNvdtfo9RqatMC639F+6oryb3BuMy++Ij4Yoi8WnPBs5Sww==",
           "requires": {
-            "@aws-sdk/credential-provider-env": "3.272.0",
-            "@aws-sdk/credential-provider-imds": "3.272.0",
-            "@aws-sdk/credential-provider-process": "3.272.0",
-            "@aws-sdk/credential-provider-sso": "3.281.0",
-            "@aws-sdk/credential-provider-web-identity": "3.272.0",
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/shared-ini-file-loader": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/credential-provider-env": "3.310.0",
+            "@aws-sdk/credential-provider-imds": "3.310.0",
+            "@aws-sdk/credential-provider-process": "3.310.0",
+            "@aws-sdk/credential-provider-sso": "3.321.1",
+            "@aws-sdk/credential-provider-web-identity": "3.310.0",
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/shared-ini-file-loader": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/credential-provider-node": {
-          "version": "3.281.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.281.0.tgz",
-          "integrity": "sha512-jhddd+lJp8G8hBJ+6glmXjfWJT3nxiE1aliH3fBC4RR3D+1kRXc99Xg6mbUb8bm+GrVZ4gzfiqSgg+ByKjd7xA==",
+          "version": "3.321.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.321.1.tgz",
+          "integrity": "sha512-5B1waOwSvY2JMLGRebo7IUqnTaGoCnby9cRbG/dhi7Ke97M3V8380S9THDJ/bktjL8zHEVfBVZy7HhXHzhSjEg==",
           "requires": {
-            "@aws-sdk/credential-provider-env": "3.272.0",
-            "@aws-sdk/credential-provider-imds": "3.272.0",
-            "@aws-sdk/credential-provider-ini": "3.281.0",
-            "@aws-sdk/credential-provider-process": "3.272.0",
-            "@aws-sdk/credential-provider-sso": "3.281.0",
-            "@aws-sdk/credential-provider-web-identity": "3.272.0",
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/shared-ini-file-loader": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/credential-provider-env": "3.310.0",
+            "@aws-sdk/credential-provider-imds": "3.310.0",
+            "@aws-sdk/credential-provider-ini": "3.321.1",
+            "@aws-sdk/credential-provider-process": "3.310.0",
+            "@aws-sdk/credential-provider-sso": "3.321.1",
+            "@aws-sdk/credential-provider-web-identity": "3.310.0",
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/shared-ini-file-loader": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/credential-provider-process": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.272.0.tgz",
-          "integrity": "sha512-hiCAjWWm2PeBFp5cjkxqyam/XADjiS+e7GzwC34TbZn3LisS0uoweLojj9tD11NnnUhyhbLteUvu5+rotOLwrg==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.310.0.tgz",
+          "integrity": "sha512-h73sg6GPMUWC+3zMCbA1nZ2O03nNJt7G96JdmnantiXBwHpRKWW8nBTLzx5uhXn6hTuTaoQRP/P+oxQJKYdMmA==",
           "requires": {
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/shared-ini-file-loader": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/shared-ini-file-loader": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/credential-provider-sso": {
-          "version": "3.281.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.281.0.tgz",
-          "integrity": "sha512-IqJnpXuLpJYoSCf/Rt66/CPVTjfkam3z9+ZvlQJV+VbK+vGj276qEtTmSN3XPZZgF1XbWptvkzIWDszLhHiZmg==",
+          "version": "3.321.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.321.1.tgz",
+          "integrity": "sha512-kg0rc1OacJFgAvmZj0TOu+BSc+yRdnC5dO/RAag3XU6+hlQI5/C080RQp9Qj6V7ga0HtAJMRwJcUlCPA3RJPug==",
           "requires": {
-            "@aws-sdk/client-sso": "3.281.0",
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/shared-ini-file-loader": "3.272.0",
-            "@aws-sdk/token-providers": "3.281.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/client-sso": "3.321.1",
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/shared-ini-file-loader": "3.310.0",
+            "@aws-sdk/token-providers": "3.321.1",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/credential-provider-web-identity": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.272.0.tgz",
-          "integrity": "sha512-ImrHMkcgneGa/HadHAQXPwOrX26sAKuB8qlMxZF/ZCM2B55u8deY+ZVkVuraeKb7YsahMGehPFOfRAF6mvFI5Q==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.310.0.tgz",
+          "integrity": "sha512-H4SzuZXILNhK6/IR1uVvsUDZvzc051hem7GLyYghBCu8mU+tq28YhKE8MfSroi6eL2e5Vujloij1OM2EQQkPkw==",
           "requires": {
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/fetch-http-handler": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.272.0.tgz",
-          "integrity": "sha512-1Qhm9e0RbS1Xf4CZqUbQyUMkDLd7GrsRXWIvm9b86/vgeV8/WnjO3CMue9D51nYgcyQORhYXv6uVjAYCWbUExA==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.310.0.tgz",
+          "integrity": "sha512-Bi9vIwzdkw1zMcvi/zGzlWS9KfIEnAq4NNhsnCxbQ4OoIRU9wvU+WGZdBBhxg0ZxZmpp1j1aZhU53lLjA07MHw==",
           "requires": {
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/querystring-builder": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/querystring-builder": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-base64": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/hash-node": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.272.0.tgz",
-          "integrity": "sha512-40dwND+iAm3VtPHPZu7/+CIdVJFk2s0cWZt1lOiMPMSXycSYJ45wMk7Lly3uoqRx0uWfFK5iT2OCv+fJi5jTng==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.310.0.tgz",
+          "integrity": "sha512-NvE2fhRc8GRwCXBfDehxVAWCmVwVMILliAKVPAEr4yz2CkYs0tqU51S48x23dtna07H4qHtgpeNqVTthcIQOEQ==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/util-buffer-from": "3.208.0",
-            "@aws-sdk/util-utf8": "3.254.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-buffer-from": "3.310.0",
+            "@aws-sdk/util-utf8": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/invalid-dependency": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.272.0.tgz",
-          "integrity": "sha512-ysW6wbjl1Y78txHUQ/Tldj2Rg1BI7rpMO9B9xAF6yAX3mQ7t6SUPQG/ewOGvH2208NBIl3qP5e/hDf0Q6r/1iw==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.310.0.tgz",
+          "integrity": "sha512-1s5RG5rSPXoa/aZ/Kqr5U/7lqpx+Ry81GprQ2bxWqJvWQIJ0IRUwo5pk8XFxbKVr/2a+4lZT/c3OGoBOM1yRRA==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
+          "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
+          "requires": {
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/middleware-content-length": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.272.0.tgz",
-          "integrity": "sha512-sAbDZSTNmLX+UTGwlUHJBWy0QGQkiClpHwVFXACon+aG0ySLNeRKEVYs6NCPYldw4cj6hveLUn50cX44ukHErw==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.310.0.tgz",
+          "integrity": "sha512-P8tQZxgDt6CAh1wd/W6WPzjc+uWPJwQkm+F7rAwRlM+k9q17HrhnksGDKcpuuLyIhPQYdmOMIkpKVgXGa4avhQ==",
           "requires": {
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/middleware-endpoint": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.272.0.tgz",
-          "integrity": "sha512-Dk3JVjj7SxxoUKv3xGiOeBksvPtFhTDrVW75XJ98Ymv8gJH5L1sq4hIeJAHRKogGiRFq2J73mnZSlM9FVXEylg==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.310.0.tgz",
+          "integrity": "sha512-Z+N2vOL8K354/lstkClxLLsr6hCpVRh+0tCMXrVj66/NtKysCEZ/0b9LmqOwD9pWHNiI2mJqXwY0gxNlKAroUg==",
           "requires": {
-            "@aws-sdk/middleware-serde": "3.272.0",
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/signature-v4": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/url-parser": "3.272.0",
-            "@aws-sdk/util-config-provider": "3.208.0",
-            "@aws-sdk/util-middleware": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/middleware-serde": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/url-parser": "3.310.0",
+            "@aws-sdk/util-middleware": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/middleware-host-header": {
-          "version": "3.278.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.278.0.tgz",
-          "integrity": "sha512-oTkF3exy89KE8NgSeXFwD+0H0GRKL2qUw92t3caEj7+4KzU/0m3t7NtKlq2NLRtTJhZ/izYRpV536oogLzGm3g==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.310.0.tgz",
+          "integrity": "sha512-QWSA+46/hXorXyWa61ic2K7qZzwHTiwfk2e9mRRjeIRepUgI3qxFjsYqrWtrOGBjmFmq0pYIY8Bb/DCJuQqcoA==",
           "requires": {
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/middleware-logger": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.272.0.tgz",
-          "integrity": "sha512-u2SQ0hWrFwxbxxYMG5uMEgf01pQY5jauK/LYWgGIvuCmFgiyRQQP3oN7kkmsxnS9MWmNmhbyQguX2NY02s5e9w==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.310.0.tgz",
+          "integrity": "sha512-Lurm8XofrASBRnAVtiSNuDSRsRqPNg27RIFLLsLp/pqog9nFJ0vz0kgdb9S5Z+zw83Mm+UlqOe6D8NTUNp4fVg==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/middleware-recursion-detection": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.272.0.tgz",
-          "integrity": "sha512-Gp/eKWeUWVNiiBdmUM2qLkBv+VLSJKoWAO+aKmyxxwjjmWhE0FrfA1NQ1a3g+NGMhRbAfQdaYswRAKsul70ISg==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.310.0.tgz",
+          "integrity": "sha512-SuB75/xk/gyue24gkriTwO2jFd7YcUGZDClQYuRejgbXSa3CO0lWyawQtfLcSSEBp9izrEVXuFH24K1eAft5nQ==",
           "requires": {
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/middleware-retry": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.272.0.tgz",
-          "integrity": "sha512-pCGvHM7C76VbO/dFerH+Vwf7tGv7j+e+eGrvhQ35mRghCtfIou/WMfTZlD1TNee93crrAQQVZKjtW3dMB3WCzg==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.310.0.tgz",
+          "integrity": "sha512-oTPsRy2W4s+dfxbJPW7Km+hHtv/OMsNsVfThAq8DDYKC13qlr1aAyOqGLD+dpBy2aKe7ss517Sy2HcHtHqm7/g==",
           "requires": {
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/service-error-classification": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/util-middleware": "3.272.0",
-            "@aws-sdk/util-retry": "3.272.0",
-            "tslib": "^2.3.1",
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/service-error-classification": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-middleware": "3.310.0",
+            "@aws-sdk/util-retry": "3.310.0",
+            "tslib": "^2.5.0",
             "uuid": "^8.3.2"
           }
         },
         "@aws-sdk/middleware-sdk-sts": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.272.0.tgz",
-          "integrity": "sha512-VvYPg7LrDIjUOWueSzo2wBzcNG7dw+cmzV6zAKaLxf0RC5jeAP4hE0OzDiiZfDrjNghEzgq/V+0NO+LewqYL9Q==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.310.0.tgz",
+          "integrity": "sha512-+5PFwlYNLvLLIfw0ASAoWV/iIF8Zv6R6QGtyP0CclhRSvNjgbQDVnV0g95MC5qvh+GB/Yjlkt8qAjLSPjHfsrQ==",
           "requires": {
-            "@aws-sdk/middleware-signing": "3.272.0",
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/signature-v4": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/middleware-signing": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/middleware-serde": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.272.0.tgz",
-          "integrity": "sha512-kW1uOxgPSwtXPB5rm3QLdWomu42lkYpQL94tM1BjyFOWmBLO2lQhk5a7Dw6HkTozT9a+vxtscLChRa6KZe61Hw==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.310.0.tgz",
+          "integrity": "sha512-RNeeTVWSLTaentUeCgQKZhAl+C6hxtwD78cQWS10UymWpQFwbaxztzKUu4UQS5xA2j6PxwPRRUjqa4jcFjfLsg==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/middleware-signing": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.272.0.tgz",
-          "integrity": "sha512-4LChFK4VAR91X+dupqM8fQqYhFGE0G4Bf9rQlVTgGSbi2KUOmpqXzH0/WKE228nKuEhmH8+Qd2VPSAE2JcyAUA==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.310.0.tgz",
+          "integrity": "sha512-f9mKq+XMdW207Af3hKjdTnpNhdtwqWuvFs/ZyXoOkp/g1MY1O6L23Jy6i52m29LxbT4AuNRG1oKODfXM0vYVjQ==",
           "requires": {
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/signature-v4": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/util-middleware": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/signature-v4": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-middleware": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/middleware-stack": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.272.0.tgz",
-          "integrity": "sha512-jhwhknnPBGhfXAGV5GXUWfEhDFoP/DN8MPCO2yC5OAxyp6oVJ8lTPLkZYMTW5VL0c0eG44dXpF4Ib01V+PlDrQ==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.310.0.tgz",
+          "integrity": "sha512-010O1PD+UAcZVKRvqEusE1KJqN96wwrf6QsqbRM0ywsKQ21NDweaHvEDlds2VHpgmofxkRLRu/IDrlPkKRQrRg==",
           "requires": {
-            "tslib": "^2.3.1"
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/middleware-user-agent": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.272.0.tgz",
-          "integrity": "sha512-Qy7/0fsDJxY5l0bEk7WKDfqb4Os/sCAgFR2zEvrhDtbkhYPf72ysvg/nRUTncmCbo8tOok4SJii2myk8KMfjjw==",
+          "version": "3.319.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.319.0.tgz",
+          "integrity": "sha512-ytaLx2dlR5AdMSne6FuDCISVg8hjyKj+cHU20b2CRA/E/z+XXrLrssp4JrCgizRKPPUep0psMIa22Zd6osTT5Q==",
           "requires": {
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-endpoints": "3.319.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/node-config-provider": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.272.0.tgz",
-          "integrity": "sha512-YYCIBh9g1EQo7hm2l22HX5Yr9RoPQ2RCvhzKvF1n1e8t1QH4iObQrYUtqHG4khcm64Cft8C5MwZmgzHbya5Z6Q==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.310.0.tgz",
+          "integrity": "sha512-T/Pp6htc6hq/Cq+MLNDSyiwWCMVF6GqbBbXKVlO5L8rdHx4sq9xPdoPveZhGWrxvkanjA6eCwUp6E0riBOSVng==",
           "requires": {
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/shared-ini-file-loader": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/shared-ini-file-loader": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/node-http-handler": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.272.0.tgz",
-          "integrity": "sha512-VrW9PjhhngeyYp4yGYPe5S0vgZH6NwU3Po9xAgayUeE37Inr7LS1YteFMHdpgsUUeNXnh7d06CXqHo1XjtqOKA==",
+          "version": "3.321.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.321.1.tgz",
+          "integrity": "sha512-DdQBrtFFDNtzphJIN3s93Vf+qd9LHSzH6WTQRrWoXhTDMHDzSI2Cn+c5KWfk89Nggp/n3+OTwUPQeCiBT5EBuw==",
           "requires": {
-            "@aws-sdk/abort-controller": "3.272.0",
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/querystring-builder": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/abort-controller": "3.310.0",
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/querystring-builder": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/property-provider": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.272.0.tgz",
-          "integrity": "sha512-V1pZTaH5eqpAt8O8CzbItHhOtzIfFuWymvwZFkAtwKuaHpnl7jjrTouV482zoq8AD/fF+VVSshwBKYA7bhidIw==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.310.0.tgz",
+          "integrity": "sha512-3lxDb0akV6BBzmFe4nLPaoliQbAifyWJhuvuDOu7e8NzouvpQXs0275w9LePhhcgjKAEVXUIse05ZW2DLbxo/g==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/protocol-http": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.272.0.tgz",
-          "integrity": "sha512-4JQ54v5Yn08jspNDeHo45CaSn1CvTJqS1Ywgr79eU6jBExtguOWv6LNtwVSBD9X37v88iqaxt8iu1Z3pZZAJeg==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.310.0.tgz",
+          "integrity": "sha512-fgZ1aw/irQtnrsR58pS8ThKOWo57Py3xX6giRvwSgZDEcxHfVzuQjy9yPuV++v04fdmdtgpbGf8WfvAAJ11yXQ==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/querystring-builder": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.272.0.tgz",
-          "integrity": "sha512-ndo++7GkdCj5tBXE6rGcITpSpZS4PfyV38wntGYAlj9liL1omk3bLZRY6uzqqkJpVHqbg2fD7O2qHNItzZgqhw==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.310.0.tgz",
+          "integrity": "sha512-ZHH8GV/80+pWGo7DzsvwvXR5xVxUHXUvPJPFAkhr6nCf78igdoF8gR10ScFoEKbtEapoNTaZlKHPXxpD8aPG7A==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/util-uri-escape": "3.201.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-uri-escape": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/querystring-parser": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.272.0.tgz",
-          "integrity": "sha512-5oS4/9n6N1LZW9tI3qq/0GnCuWoOXRgcHVB+AJLRBvDbEe+GI+C/xK1tKLsfpDNgsQJHc4IPQoIt4megyZ/1+A==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.310.0.tgz",
+          "integrity": "sha512-YkIznoP6lsiIUHinx++/lbb3tlMURGGqMpo0Pnn32zYzGrJXA6eC3D0as2EcMjo55onTfuLcIiX4qzXes2MYOA==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/service-error-classification": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.272.0.tgz",
-          "integrity": "sha512-REoltM1LK9byyIufLqx9znhSolPcHQgVHIA2S0zu5sdt5qER4OubkLAXuo4MBbisUTmh8VOOvIyUb5ijZCXq1w=="
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.310.0.tgz",
+          "integrity": "sha512-PuyC7k3qfIKeH2LCnDwbttMOKq3qAx4buvg0yfnJtQOz6t1AR8gsnAq0CjKXXyfkXwNKWTqCpE6lVNUIkXgsMw=="
         },
         "@aws-sdk/shared-ini-file-loader": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.272.0.tgz",
-          "integrity": "sha512-lzFPohp5sy2XvwFjZIzLVCRpC0i5cwBiaXmFzXYQZJm6FSCszHO4ax+m9yrtlyVFF/2YPWl+/bzNthy4aJtseA==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.310.0.tgz",
+          "integrity": "sha512-N0q9pG0xSjQwc690YQND5bofm+4nfUviQ/Ppgan2kU6aU0WUq8KwgHJBto/YEEI+VlrME30jZJnxtOvcZJc2XA==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/signature-v4": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.272.0.tgz",
-          "integrity": "sha512-pWxnHG1NqJWMwlhJ6NHNiUikOL00DHROmxah6krJPMPq4I3am2KY2Rs/8ouWhnEXKaHAv4EQhSALJ+7Mq5S4/A==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.310.0.tgz",
+          "integrity": "sha512-1M60P1ZBNAjCFv9sYW29OF6okktaeibWyW3lMXqzoHF70lHBZh+838iUchznXUA5FLabfn4jBFWMRxlAXJUY2Q==",
           "requires": {
-            "@aws-sdk/is-array-buffer": "3.201.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/util-hex-encoding": "3.201.0",
-            "@aws-sdk/util-middleware": "3.272.0",
-            "@aws-sdk/util-uri-escape": "3.201.0",
-            "@aws-sdk/util-utf8": "3.254.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/is-array-buffer": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-hex-encoding": "3.310.0",
+            "@aws-sdk/util-middleware": "3.310.0",
+            "@aws-sdk/util-uri-escape": "3.310.0",
+            "@aws-sdk/util-utf8": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/smithy-client": {
-          "version": "3.279.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.279.0.tgz",
-          "integrity": "sha512-ZcYWUQDGAYN6NXRpJuSn46PetrpPCA6TrDVwP9+3pERzTXZ66npXoG2XhHjNrOXy/Ted5A3OxKrM4/zLu9tK3A==",
+          "version": "3.316.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.316.0.tgz",
+          "integrity": "sha512-6YXOKbRnXeS8r8RWzuL6JMBolDYM5Wa4fD/VY6x/wK78i2xErHOvqzHgyyeLI1MMw4uqyd4wRNJNWC9TMPduXw==",
           "requires": {
-            "@aws-sdk/middleware-stack": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/middleware-stack": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/token-providers": {
-          "version": "3.281.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.281.0.tgz",
-          "integrity": "sha512-36Vg/F6Edm7qdjcTeNVON+sK2edgHhmhTtAEjWcuUk5AX/Et+Ate/A2N8HD3nxwlAcgidfnBC9SHYJatbhcEnQ==",
+          "version": "3.321.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.321.1.tgz",
+          "integrity": "sha512-I1sXS4qXirSvgvrOIPf+e1D7GvC83DdeyMxHZvuhHgeMCqDAzToS8OLxOX0enN9xZRHWAQYja8xyeGbDL2I0Zw==",
           "requires": {
-            "@aws-sdk/client-sso-oidc": "3.281.0",
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/shared-ini-file-loader": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/client-sso-oidc": "3.321.1",
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/shared-ini-file-loader": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/types": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.272.0.tgz",
-          "integrity": "sha512-MmmL6vxMGP5Bsi+4wRx4mxYlU/LX6M0noOXrDh/x5FfG7/4ZOar/nDxqDadhJtNM88cuWVHZWY59P54JzkGWmA==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.310.0.tgz",
+          "integrity": "sha512-j8eamQJ7YcIhw7fneUfs8LYl3t01k4uHi4ZDmNRgtbmbmTTG3FZc2MotStZnp3nZB6vLiPF1o5aoJxWVvkzS6A==",
           "requires": {
-            "tslib": "^2.3.1"
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/url-parser": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.272.0.tgz",
-          "integrity": "sha512-vX/Tx02PlnQ/Kgtf5TnrNDHPNbY+amLZjW0Z1d9vzAvSZhQ4i9Y18yxoRDIaDTCNVRDjdhV8iuctW+05PB5JtQ==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.310.0.tgz",
+          "integrity": "sha512-mCLnCaSB9rQvAgx33u0DujLvr4d5yEm/W5r789GblwwQnlNXedVu50QRizMLTpltYWyAUoXjJgQnJHmJMaKXhw==",
           "requires": {
-            "@aws-sdk/querystring-parser": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/querystring-parser": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-base64": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
+          "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-body-length-browser": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
+          "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
+          "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
+          "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-config-provider": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
+          "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
+          "requires": {
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/util-defaults-mode-browser": {
-          "version": "3.279.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.279.0.tgz",
-          "integrity": "sha512-RnchYRrpapTT5Hu23LOfk6e8RMVq0kUzho6xA6TJj1a4uGxkcRMvgzPipCq1P5uHu0mrkQBg9pGPEVNOUs38/Q==",
+          "version": "3.316.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.316.0.tgz",
+          "integrity": "sha512-6FSqLhYmaihtH2n1s4b2rlLW0ABU8N6VZIfzLfe2ING4PF0MzfaMMhnTFUHVXfKCVGoR8yP6iyFTRCyHGVEL1w==",
           "requires": {
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
             "bowser": "^2.11.0",
-            "tslib": "^2.3.1"
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/util-defaults-mode-node": {
-          "version": "3.279.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.279.0.tgz",
-          "integrity": "sha512-A2NB10xReWC+GSnOivKGZ9rnljIZdEP8WMCQQEnA6DJNI19AUFF/O9QJ9y+cHGLKEms7jH86Y99wShdpzAK+Jw==",
+          "version": "3.316.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.316.0.tgz",
+          "integrity": "sha512-dkYy10hdjPSScXXvnjGpZpnJxllkb6ICHgLMwZ4JczLHhPM12T/4PQ758YN8HS+muiYDGX1Bl2z1jd/bMcewBQ==",
           "requires": {
-            "@aws-sdk/config-resolver": "3.272.0",
-            "@aws-sdk/credential-provider-imds": "3.272.0",
-            "@aws-sdk/node-config-provider": "3.272.0",
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/config-resolver": "3.310.0",
+            "@aws-sdk/credential-provider-imds": "3.310.0",
+            "@aws-sdk/node-config-provider": "3.310.0",
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/util-endpoints": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.272.0.tgz",
-          "integrity": "sha512-c4MPUaJt2G6gGpoiwIOqDfUa98c1J63RpYvf/spQEKOtC/tF5Gfqlxuq8FnAl5lHnrqj1B9ZXLLxFhHtDR0IiQ==",
+          "version": "3.319.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.319.0.tgz",
+          "integrity": "sha512-3I64UMoYA2e2++oOUJXRcFtYLpLylnZFRltWfPo1B3dLlf+MIWat9djT+mMus+hW1ntLsvAIVu1hLVePJC0gvw==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
+          "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
+          "requires": {
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/util-middleware": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.272.0.tgz",
-          "integrity": "sha512-Abw8m30arbwxqmeMMha5J11ESpHUNmCeSqSzE8/C4B8jZQtHY4kq7f+upzcNIQ11lsd+uzBEzNG3+dDRi0XOJQ==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.310.0.tgz",
+          "integrity": "sha512-FTSUKL/eRb9X6uEZClrTe27QFXUNNp7fxYrPndZwk1hlaOP5ix+MIHBcI7pIiiY/JPfOUmPyZOu+HetlFXjWog==",
           "requires": {
-            "tslib": "^2.3.1"
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/util-retry": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.272.0.tgz",
-          "integrity": "sha512-Ngha5414LR4gRHURVKC9ZYXsEJhMkm+SJ+44wlzOhavglfdcKKPUsibz5cKY1jpUV7oKECwaxHWpBB8r6h+hOg==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.310.0.tgz",
+          "integrity": "sha512-FwWGhCBLfoivTMUHu1LIn4NjrN9JLJ/aX5aZmbcPIOhZVFJj638j0qDgZXyfvVqBuBZh7M8kGq0Oahy3dp69OA==",
           "requires": {
-            "@aws-sdk/service-error-classification": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/service-error-classification": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
+          "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
+          "requires": {
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/util-user-agent-browser": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.272.0.tgz",
-          "integrity": "sha512-Lp5QX5bH6uuwBlIdr7w7OAcAI50ttyskb++yUr9i+SPvj6RI2dsfIBaK4mDg1qUdM5LeUdvIyqwj3XHjFKAAvA==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.310.0.tgz",
+          "integrity": "sha512-yU/4QnHHuQ5z3vsUqMQVfYLbZGYwpYblPiuZx4Zo9+x0PBkNjYMqctdDcrpoH9Z2xZiDN16AmQGK1tix117ZKw==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
+            "@aws-sdk/types": "3.310.0",
             "bowser": "^2.11.0",
-            "tslib": "^2.3.1"
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/util-user-agent-node": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.272.0.tgz",
-          "integrity": "sha512-ljK+R3l+Q1LIHrcR+Knhk0rmcSkfFadZ8V+crEGpABf/QUQRg7NkZMsoe814tfBO5F7tMxo8wwwSdaVNNHtoRA==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.310.0.tgz",
+          "integrity": "sha512-Ra3pEl+Gn2BpeE7KiDGpi4zj7WJXZA5GXnGo3mjbi9+Y3zrbuhJAbdZO3mO/o7xDgMC6ph4xCTbaSGzU6b6EDg==",
           "requires": {
-            "@aws-sdk/node-config-provider": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/node-config-provider": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "fast-xml-parser": {
@@ -23058,6 +23779,30 @@
             "tslib": "^2.3.1"
           }
         },
+        "@aws-sdk/util-stream-browser": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.272.0.tgz",
+          "integrity": "sha512-vD514YffKxBjV/erjUNgkXcb/mzXAz3uk/KUFMXsodo3cA4Z8WxL4P0p1O09FVuJlNa0gZ8mhFPNzNOekh31GA==",
+          "requires": {
+            "@aws-sdk/fetch-http-handler": "3.272.0",
+            "@aws-sdk/types": "3.272.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-hex-encoding": "3.201.0",
+            "@aws-sdk/util-utf8": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-stream-node": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.272.0.tgz",
+          "integrity": "sha512-s7dGeM1ImzihqBKgrpaeZokLnPUk3H4Et5oiM+t+TpRxotXTecJPyuD0p76HRgO8KSXfVT5Nxw/FoHXqj1fiMg==",
+          "requires": {
+            "@aws-sdk/node-http-handler": "3.272.0",
+            "@aws-sdk/types": "3.272.0",
+            "@aws-sdk/util-buffer-from": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
         "@aws-sdk/util-user-agent-browser": {
           "version": "3.272.0",
           "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.272.0.tgz",
@@ -23078,6 +23823,25 @@
             "tslib": "^2.3.1"
           }
         },
+        "@aws-sdk/util-utf8": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.254.0.tgz",
+          "integrity": "sha512-14Kso/eIt5/qfIBmhEL9L1IfyUqswjSTqO2mY7KOzUZ9SZbwn3rpxmtkhmATkRjD7XIlLKaxBkI7tU9Zjzj8Kw==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-waiter": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.272.0.tgz",
+          "integrity": "sha512-N25/XsJ2wkPh1EgkFyb/GRgfHDityScfD49Hk1AwJWpfetzgkcEtWdeW4IuPymXlSKhrm5L+SBw49USxo9kBag==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.272.0",
+            "@aws-sdk/types": "3.272.0",
+            "tslib": "^2.3.1"
+          }
+        },
         "fast-xml-parser": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
@@ -23089,45 +23853,45 @@
       }
     },
     "@aws-sdk/client-secrets-manager": {
-      "version": "3.281.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.281.0.tgz",
-      "integrity": "sha512-vL+LygNDoCja/47pFwSnI3tCWfy5SGHlz6C1whcszmfl81gXyuHNlAK8RXVRiKhnD11zmCsHJhZyYSfTz5RErQ==",
+      "version": "3.321.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.321.1.tgz",
+      "integrity": "sha512-OlZzn7I2PYaTRJycK88NeB++VwQqnEHbnHMhKKcFkjUzHD3w1hZkkHr0T5XbgDtXmWZUW3u24+3BtV1xtjAzHQ==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.281.0",
-        "@aws-sdk/config-resolver": "3.272.0",
-        "@aws-sdk/credential-provider-node": "3.281.0",
-        "@aws-sdk/fetch-http-handler": "3.272.0",
-        "@aws-sdk/hash-node": "3.272.0",
-        "@aws-sdk/invalid-dependency": "3.272.0",
-        "@aws-sdk/middleware-content-length": "3.272.0",
-        "@aws-sdk/middleware-endpoint": "3.272.0",
-        "@aws-sdk/middleware-host-header": "3.278.0",
-        "@aws-sdk/middleware-logger": "3.272.0",
-        "@aws-sdk/middleware-recursion-detection": "3.272.0",
-        "@aws-sdk/middleware-retry": "3.272.0",
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/middleware-signing": "3.272.0",
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/middleware-user-agent": "3.272.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/node-http-handler": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/smithy-client": "3.279.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-        "@aws-sdk/util-defaults-mode-node": "3.279.0",
-        "@aws-sdk/util-endpoints": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "@aws-sdk/util-user-agent-browser": "3.272.0",
-        "@aws-sdk/util-user-agent-node": "3.272.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1",
+        "@aws-sdk/client-sts": "3.321.1",
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/credential-provider-node": "3.321.1",
+        "@aws-sdk/fetch-http-handler": "3.310.0",
+        "@aws-sdk/hash-node": "3.310.0",
+        "@aws-sdk/invalid-dependency": "3.310.0",
+        "@aws-sdk/middleware-content-length": "3.310.0",
+        "@aws-sdk/middleware-endpoint": "3.310.0",
+        "@aws-sdk/middleware-host-header": "3.310.0",
+        "@aws-sdk/middleware-logger": "3.310.0",
+        "@aws-sdk/middleware-recursion-detection": "3.310.0",
+        "@aws-sdk/middleware-retry": "3.310.0",
+        "@aws-sdk/middleware-serde": "3.310.0",
+        "@aws-sdk/middleware-signing": "3.310.0",
+        "@aws-sdk/middleware-stack": "3.310.0",
+        "@aws-sdk/middleware-user-agent": "3.319.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/node-http-handler": "3.321.1",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/smithy-client": "3.316.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+        "@aws-sdk/util-defaults-mode-node": "3.316.0",
+        "@aws-sdk/util-endpoints": "3.319.0",
+        "@aws-sdk/util-retry": "3.310.0",
+        "@aws-sdk/util-user-agent-browser": "3.310.0",
+        "@aws-sdk/util-user-agent-node": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0",
         "uuid": "^8.3.2"
       },
       "dependencies": {
@@ -23218,585 +23982,645 @@
           }
         },
         "@aws-sdk/abort-controller": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.272.0.tgz",
-          "integrity": "sha512-s2TV3phapcTwZNr4qLxbfuQuE9ZMP4RoJdkvRRCkKdm6jslsWLJf2Zlcxti/23hOlINUMYv2iXE2pftIgWGdpg==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.310.0.tgz",
+          "integrity": "sha512-v1zrRQxDLA1MdPim159Vx/CPHqsB4uybSxRi1CnfHO5ZjHryx3a5htW2gdGAykVCul40+yJXvfpufMrELVxH+g==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/client-sso": {
-          "version": "3.281.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.281.0.tgz",
-          "integrity": "sha512-3RvO5zClQhu37w9VMLoHPGk58S3y8Spb7XX8rW51bm5TUglYQskQ0X2VLEUW/7ZGx/peokHws9Z9+w5yGq5sdA==",
+          "version": "3.321.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.321.1.tgz",
+          "integrity": "sha512-ecoT4tBGtRJR5G7oLBTMXZmgZZlff1amhSdKPEtkWxv6kWc8VPb5rRuRgVPsDR9HuesI6ZVlODptvGtnfkIJwA==",
           "requires": {
             "@aws-crypto/sha256-browser": "3.0.0",
             "@aws-crypto/sha256-js": "3.0.0",
-            "@aws-sdk/config-resolver": "3.272.0",
-            "@aws-sdk/fetch-http-handler": "3.272.0",
-            "@aws-sdk/hash-node": "3.272.0",
-            "@aws-sdk/invalid-dependency": "3.272.0",
-            "@aws-sdk/middleware-content-length": "3.272.0",
-            "@aws-sdk/middleware-endpoint": "3.272.0",
-            "@aws-sdk/middleware-host-header": "3.278.0",
-            "@aws-sdk/middleware-logger": "3.272.0",
-            "@aws-sdk/middleware-recursion-detection": "3.272.0",
-            "@aws-sdk/middleware-retry": "3.272.0",
-            "@aws-sdk/middleware-serde": "3.272.0",
-            "@aws-sdk/middleware-stack": "3.272.0",
-            "@aws-sdk/middleware-user-agent": "3.272.0",
-            "@aws-sdk/node-config-provider": "3.272.0",
-            "@aws-sdk/node-http-handler": "3.272.0",
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/smithy-client": "3.279.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/url-parser": "3.272.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-            "@aws-sdk/util-defaults-mode-node": "3.279.0",
-            "@aws-sdk/util-endpoints": "3.272.0",
-            "@aws-sdk/util-retry": "3.272.0",
-            "@aws-sdk/util-user-agent-browser": "3.272.0",
-            "@aws-sdk/util-user-agent-node": "3.272.0",
-            "@aws-sdk/util-utf8": "3.254.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/config-resolver": "3.310.0",
+            "@aws-sdk/fetch-http-handler": "3.310.0",
+            "@aws-sdk/hash-node": "3.310.0",
+            "@aws-sdk/invalid-dependency": "3.310.0",
+            "@aws-sdk/middleware-content-length": "3.310.0",
+            "@aws-sdk/middleware-endpoint": "3.310.0",
+            "@aws-sdk/middleware-host-header": "3.310.0",
+            "@aws-sdk/middleware-logger": "3.310.0",
+            "@aws-sdk/middleware-recursion-detection": "3.310.0",
+            "@aws-sdk/middleware-retry": "3.310.0",
+            "@aws-sdk/middleware-serde": "3.310.0",
+            "@aws-sdk/middleware-stack": "3.310.0",
+            "@aws-sdk/middleware-user-agent": "3.319.0",
+            "@aws-sdk/node-config-provider": "3.310.0",
+            "@aws-sdk/node-http-handler": "3.321.1",
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/smithy-client": "3.316.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/url-parser": "3.310.0",
+            "@aws-sdk/util-base64": "3.310.0",
+            "@aws-sdk/util-body-length-browser": "3.310.0",
+            "@aws-sdk/util-body-length-node": "3.310.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+            "@aws-sdk/util-defaults-mode-node": "3.316.0",
+            "@aws-sdk/util-endpoints": "3.319.0",
+            "@aws-sdk/util-retry": "3.310.0",
+            "@aws-sdk/util-user-agent-browser": "3.310.0",
+            "@aws-sdk/util-user-agent-node": "3.310.0",
+            "@aws-sdk/util-utf8": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/client-sso-oidc": {
-          "version": "3.281.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.281.0.tgz",
-          "integrity": "sha512-P6zf9pDuxApVoCYStAg7L8BU9AcWI8PxfLSX4r2WnmcQropxzPJ3op1j9nvbwwBDMFWephijVY4AVp8MqPcPyg==",
+          "version": "3.321.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.321.1.tgz",
+          "integrity": "sha512-PBVfHQbyrsfzbnO6u9d9Sik8JlXGLhHj3zLd87iBkYXBdHwD5NuvwWu7OtjUtrHjP4SfzodVwfjmTbDAFqbtzw==",
           "requires": {
             "@aws-crypto/sha256-browser": "3.0.0",
             "@aws-crypto/sha256-js": "3.0.0",
-            "@aws-sdk/config-resolver": "3.272.0",
-            "@aws-sdk/fetch-http-handler": "3.272.0",
-            "@aws-sdk/hash-node": "3.272.0",
-            "@aws-sdk/invalid-dependency": "3.272.0",
-            "@aws-sdk/middleware-content-length": "3.272.0",
-            "@aws-sdk/middleware-endpoint": "3.272.0",
-            "@aws-sdk/middleware-host-header": "3.278.0",
-            "@aws-sdk/middleware-logger": "3.272.0",
-            "@aws-sdk/middleware-recursion-detection": "3.272.0",
-            "@aws-sdk/middleware-retry": "3.272.0",
-            "@aws-sdk/middleware-serde": "3.272.0",
-            "@aws-sdk/middleware-stack": "3.272.0",
-            "@aws-sdk/middleware-user-agent": "3.272.0",
-            "@aws-sdk/node-config-provider": "3.272.0",
-            "@aws-sdk/node-http-handler": "3.272.0",
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/smithy-client": "3.279.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/url-parser": "3.272.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-            "@aws-sdk/util-defaults-mode-node": "3.279.0",
-            "@aws-sdk/util-endpoints": "3.272.0",
-            "@aws-sdk/util-retry": "3.272.0",
-            "@aws-sdk/util-user-agent-browser": "3.272.0",
-            "@aws-sdk/util-user-agent-node": "3.272.0",
-            "@aws-sdk/util-utf8": "3.254.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/config-resolver": "3.310.0",
+            "@aws-sdk/fetch-http-handler": "3.310.0",
+            "@aws-sdk/hash-node": "3.310.0",
+            "@aws-sdk/invalid-dependency": "3.310.0",
+            "@aws-sdk/middleware-content-length": "3.310.0",
+            "@aws-sdk/middleware-endpoint": "3.310.0",
+            "@aws-sdk/middleware-host-header": "3.310.0",
+            "@aws-sdk/middleware-logger": "3.310.0",
+            "@aws-sdk/middleware-recursion-detection": "3.310.0",
+            "@aws-sdk/middleware-retry": "3.310.0",
+            "@aws-sdk/middleware-serde": "3.310.0",
+            "@aws-sdk/middleware-stack": "3.310.0",
+            "@aws-sdk/middleware-user-agent": "3.319.0",
+            "@aws-sdk/node-config-provider": "3.310.0",
+            "@aws-sdk/node-http-handler": "3.321.1",
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/smithy-client": "3.316.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/url-parser": "3.310.0",
+            "@aws-sdk/util-base64": "3.310.0",
+            "@aws-sdk/util-body-length-browser": "3.310.0",
+            "@aws-sdk/util-body-length-node": "3.310.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+            "@aws-sdk/util-defaults-mode-node": "3.316.0",
+            "@aws-sdk/util-endpoints": "3.319.0",
+            "@aws-sdk/util-retry": "3.310.0",
+            "@aws-sdk/util-user-agent-browser": "3.310.0",
+            "@aws-sdk/util-user-agent-node": "3.310.0",
+            "@aws-sdk/util-utf8": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/client-sts": {
-          "version": "3.281.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.281.0.tgz",
-          "integrity": "sha512-w8QomyhCVEArRcXgOkjbofiS/PLEKWRAyYBovjMS1cGhns2ZYJXFgHNgr3VGE54TghUc5dR1CqKuBKKM4ThrgA==",
+          "version": "3.321.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.321.1.tgz",
+          "integrity": "sha512-AB+N4a1TVEKl9Sd5O2TxTprEZp7Va6zPZLMraFAYMdmJVBmCmmwyBs7ygju685DpQ1dos5PRsKCRcossyY5pDQ==",
           "requires": {
             "@aws-crypto/sha256-browser": "3.0.0",
             "@aws-crypto/sha256-js": "3.0.0",
-            "@aws-sdk/config-resolver": "3.272.0",
-            "@aws-sdk/credential-provider-node": "3.281.0",
-            "@aws-sdk/fetch-http-handler": "3.272.0",
-            "@aws-sdk/hash-node": "3.272.0",
-            "@aws-sdk/invalid-dependency": "3.272.0",
-            "@aws-sdk/middleware-content-length": "3.272.0",
-            "@aws-sdk/middleware-endpoint": "3.272.0",
-            "@aws-sdk/middleware-host-header": "3.278.0",
-            "@aws-sdk/middleware-logger": "3.272.0",
-            "@aws-sdk/middleware-recursion-detection": "3.272.0",
-            "@aws-sdk/middleware-retry": "3.272.0",
-            "@aws-sdk/middleware-sdk-sts": "3.272.0",
-            "@aws-sdk/middleware-serde": "3.272.0",
-            "@aws-sdk/middleware-signing": "3.272.0",
-            "@aws-sdk/middleware-stack": "3.272.0",
-            "@aws-sdk/middleware-user-agent": "3.272.0",
-            "@aws-sdk/node-config-provider": "3.272.0",
-            "@aws-sdk/node-http-handler": "3.272.0",
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/smithy-client": "3.279.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/url-parser": "3.272.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-            "@aws-sdk/util-defaults-mode-node": "3.279.0",
-            "@aws-sdk/util-endpoints": "3.272.0",
-            "@aws-sdk/util-retry": "3.272.0",
-            "@aws-sdk/util-user-agent-browser": "3.272.0",
-            "@aws-sdk/util-user-agent-node": "3.272.0",
-            "@aws-sdk/util-utf8": "3.254.0",
+            "@aws-sdk/config-resolver": "3.310.0",
+            "@aws-sdk/credential-provider-node": "3.321.1",
+            "@aws-sdk/fetch-http-handler": "3.310.0",
+            "@aws-sdk/hash-node": "3.310.0",
+            "@aws-sdk/invalid-dependency": "3.310.0",
+            "@aws-sdk/middleware-content-length": "3.310.0",
+            "@aws-sdk/middleware-endpoint": "3.310.0",
+            "@aws-sdk/middleware-host-header": "3.310.0",
+            "@aws-sdk/middleware-logger": "3.310.0",
+            "@aws-sdk/middleware-recursion-detection": "3.310.0",
+            "@aws-sdk/middleware-retry": "3.310.0",
+            "@aws-sdk/middleware-sdk-sts": "3.310.0",
+            "@aws-sdk/middleware-serde": "3.310.0",
+            "@aws-sdk/middleware-signing": "3.310.0",
+            "@aws-sdk/middleware-stack": "3.310.0",
+            "@aws-sdk/middleware-user-agent": "3.319.0",
+            "@aws-sdk/node-config-provider": "3.310.0",
+            "@aws-sdk/node-http-handler": "3.321.1",
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/smithy-client": "3.316.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/url-parser": "3.310.0",
+            "@aws-sdk/util-base64": "3.310.0",
+            "@aws-sdk/util-body-length-browser": "3.310.0",
+            "@aws-sdk/util-body-length-node": "3.310.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+            "@aws-sdk/util-defaults-mode-node": "3.316.0",
+            "@aws-sdk/util-endpoints": "3.319.0",
+            "@aws-sdk/util-retry": "3.310.0",
+            "@aws-sdk/util-user-agent-browser": "3.310.0",
+            "@aws-sdk/util-user-agent-node": "3.310.0",
+            "@aws-sdk/util-utf8": "3.310.0",
             "fast-xml-parser": "4.1.2",
-            "tslib": "^2.3.1"
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/config-resolver": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.272.0.tgz",
-          "integrity": "sha512-Dr4CffRVNsOp3LRNdpvcH6XuSgXOSLblWliCy/5I86cNl567KVMxujVx6uPrdTXYs2h1rt3MNl6jQGnAiJeTbw==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.310.0.tgz",
+          "integrity": "sha512-8vsT+/50lOqfDxka9m/rRt6oxv1WuGZoP8oPMk0Dt+TxXMbAzf4+rejBgiB96wshI1k3gLokYRjSQZn+dDtT8g==",
           "requires": {
-            "@aws-sdk/signature-v4": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/util-config-provider": "3.208.0",
-            "@aws-sdk/util-middleware": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-config-provider": "3.310.0",
+            "@aws-sdk/util-middleware": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/credential-provider-env": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.272.0.tgz",
-          "integrity": "sha512-QI65NbLnKLYHyTYhXaaUrq6eVsCCrMUb05WDA7+TJkWkjXesovpjc8vUKgFiLSxmgKmb2uOhHNcDyObKMrYQFw==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.310.0.tgz",
+          "integrity": "sha512-vvIPQpI16fj95xwS7M3D48F7QhZJBnnCgB5lR+b7So+vsG9ibm1mZRVGzVpdxCvgyOhHFbvrby9aalNJmmIP1A==",
           "requires": {
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/credential-provider-imds": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.272.0.tgz",
-          "integrity": "sha512-wwAfVY1jTFQEfxVfdYD5r5ieYGl+0g4nhekVxNMqE8E1JeRDd18OqiwAflzpgBIqxfqvCUkf+vl5JYyacMkNAQ==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.310.0.tgz",
+          "integrity": "sha512-baxK7Zp6dai5AGW01FIW27xS2KAaPUmKLIXv5SvFYsUgXXvNW55im4uG3b+2gA0F7V+hXvVBH08OEqmwW6we5w==",
           "requires": {
-            "@aws-sdk/node-config-provider": "3.272.0",
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/url-parser": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/node-config-provider": "3.310.0",
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/url-parser": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/credential-provider-ini": {
-          "version": "3.281.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.281.0.tgz",
-          "integrity": "sha512-H99nhMhHImQKgNhHKYc6usTS6UK8KzCcVGpILLVTuP97YlrYAMFAVstA3Xk6mZ28JAbHVXvI6vJjkMNOzCSKCA==",
+          "version": "3.321.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.321.1.tgz",
+          "integrity": "sha512-prndSVQhiikNaI40bYnM2Q8PkC35FCwhbQnBk6KXNvdtfo9RqatMC639F+6oryb3BuMy++Ij4Yoi8WnPBs5Sww==",
           "requires": {
-            "@aws-sdk/credential-provider-env": "3.272.0",
-            "@aws-sdk/credential-provider-imds": "3.272.0",
-            "@aws-sdk/credential-provider-process": "3.272.0",
-            "@aws-sdk/credential-provider-sso": "3.281.0",
-            "@aws-sdk/credential-provider-web-identity": "3.272.0",
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/shared-ini-file-loader": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/credential-provider-env": "3.310.0",
+            "@aws-sdk/credential-provider-imds": "3.310.0",
+            "@aws-sdk/credential-provider-process": "3.310.0",
+            "@aws-sdk/credential-provider-sso": "3.321.1",
+            "@aws-sdk/credential-provider-web-identity": "3.310.0",
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/shared-ini-file-loader": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/credential-provider-node": {
-          "version": "3.281.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.281.0.tgz",
-          "integrity": "sha512-jhddd+lJp8G8hBJ+6glmXjfWJT3nxiE1aliH3fBC4RR3D+1kRXc99Xg6mbUb8bm+GrVZ4gzfiqSgg+ByKjd7xA==",
+          "version": "3.321.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.321.1.tgz",
+          "integrity": "sha512-5B1waOwSvY2JMLGRebo7IUqnTaGoCnby9cRbG/dhi7Ke97M3V8380S9THDJ/bktjL8zHEVfBVZy7HhXHzhSjEg==",
           "requires": {
-            "@aws-sdk/credential-provider-env": "3.272.0",
-            "@aws-sdk/credential-provider-imds": "3.272.0",
-            "@aws-sdk/credential-provider-ini": "3.281.0",
-            "@aws-sdk/credential-provider-process": "3.272.0",
-            "@aws-sdk/credential-provider-sso": "3.281.0",
-            "@aws-sdk/credential-provider-web-identity": "3.272.0",
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/shared-ini-file-loader": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/credential-provider-env": "3.310.0",
+            "@aws-sdk/credential-provider-imds": "3.310.0",
+            "@aws-sdk/credential-provider-ini": "3.321.1",
+            "@aws-sdk/credential-provider-process": "3.310.0",
+            "@aws-sdk/credential-provider-sso": "3.321.1",
+            "@aws-sdk/credential-provider-web-identity": "3.310.0",
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/shared-ini-file-loader": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/credential-provider-process": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.272.0.tgz",
-          "integrity": "sha512-hiCAjWWm2PeBFp5cjkxqyam/XADjiS+e7GzwC34TbZn3LisS0uoweLojj9tD11NnnUhyhbLteUvu5+rotOLwrg==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.310.0.tgz",
+          "integrity": "sha512-h73sg6GPMUWC+3zMCbA1nZ2O03nNJt7G96JdmnantiXBwHpRKWW8nBTLzx5uhXn6hTuTaoQRP/P+oxQJKYdMmA==",
           "requires": {
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/shared-ini-file-loader": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/shared-ini-file-loader": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/credential-provider-sso": {
-          "version": "3.281.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.281.0.tgz",
-          "integrity": "sha512-IqJnpXuLpJYoSCf/Rt66/CPVTjfkam3z9+ZvlQJV+VbK+vGj276qEtTmSN3XPZZgF1XbWptvkzIWDszLhHiZmg==",
+          "version": "3.321.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.321.1.tgz",
+          "integrity": "sha512-kg0rc1OacJFgAvmZj0TOu+BSc+yRdnC5dO/RAag3XU6+hlQI5/C080RQp9Qj6V7ga0HtAJMRwJcUlCPA3RJPug==",
           "requires": {
-            "@aws-sdk/client-sso": "3.281.0",
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/shared-ini-file-loader": "3.272.0",
-            "@aws-sdk/token-providers": "3.281.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/client-sso": "3.321.1",
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/shared-ini-file-loader": "3.310.0",
+            "@aws-sdk/token-providers": "3.321.1",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/credential-provider-web-identity": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.272.0.tgz",
-          "integrity": "sha512-ImrHMkcgneGa/HadHAQXPwOrX26sAKuB8qlMxZF/ZCM2B55u8deY+ZVkVuraeKb7YsahMGehPFOfRAF6mvFI5Q==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.310.0.tgz",
+          "integrity": "sha512-H4SzuZXILNhK6/IR1uVvsUDZvzc051hem7GLyYghBCu8mU+tq28YhKE8MfSroi6eL2e5Vujloij1OM2EQQkPkw==",
           "requires": {
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/fetch-http-handler": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.272.0.tgz",
-          "integrity": "sha512-1Qhm9e0RbS1Xf4CZqUbQyUMkDLd7GrsRXWIvm9b86/vgeV8/WnjO3CMue9D51nYgcyQORhYXv6uVjAYCWbUExA==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.310.0.tgz",
+          "integrity": "sha512-Bi9vIwzdkw1zMcvi/zGzlWS9KfIEnAq4NNhsnCxbQ4OoIRU9wvU+WGZdBBhxg0ZxZmpp1j1aZhU53lLjA07MHw==",
           "requires": {
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/querystring-builder": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/querystring-builder": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-base64": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/hash-node": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.272.0.tgz",
-          "integrity": "sha512-40dwND+iAm3VtPHPZu7/+CIdVJFk2s0cWZt1lOiMPMSXycSYJ45wMk7Lly3uoqRx0uWfFK5iT2OCv+fJi5jTng==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.310.0.tgz",
+          "integrity": "sha512-NvE2fhRc8GRwCXBfDehxVAWCmVwVMILliAKVPAEr4yz2CkYs0tqU51S48x23dtna07H4qHtgpeNqVTthcIQOEQ==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/util-buffer-from": "3.208.0",
-            "@aws-sdk/util-utf8": "3.254.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-buffer-from": "3.310.0",
+            "@aws-sdk/util-utf8": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/invalid-dependency": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.272.0.tgz",
-          "integrity": "sha512-ysW6wbjl1Y78txHUQ/Tldj2Rg1BI7rpMO9B9xAF6yAX3mQ7t6SUPQG/ewOGvH2208NBIl3qP5e/hDf0Q6r/1iw==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.310.0.tgz",
+          "integrity": "sha512-1s5RG5rSPXoa/aZ/Kqr5U/7lqpx+Ry81GprQ2bxWqJvWQIJ0IRUwo5pk8XFxbKVr/2a+4lZT/c3OGoBOM1yRRA==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
+          "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
+          "requires": {
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/middleware-content-length": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.272.0.tgz",
-          "integrity": "sha512-sAbDZSTNmLX+UTGwlUHJBWy0QGQkiClpHwVFXACon+aG0ySLNeRKEVYs6NCPYldw4cj6hveLUn50cX44ukHErw==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.310.0.tgz",
+          "integrity": "sha512-P8tQZxgDt6CAh1wd/W6WPzjc+uWPJwQkm+F7rAwRlM+k9q17HrhnksGDKcpuuLyIhPQYdmOMIkpKVgXGa4avhQ==",
           "requires": {
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/middleware-endpoint": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.272.0.tgz",
-          "integrity": "sha512-Dk3JVjj7SxxoUKv3xGiOeBksvPtFhTDrVW75XJ98Ymv8gJH5L1sq4hIeJAHRKogGiRFq2J73mnZSlM9FVXEylg==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.310.0.tgz",
+          "integrity": "sha512-Z+N2vOL8K354/lstkClxLLsr6hCpVRh+0tCMXrVj66/NtKysCEZ/0b9LmqOwD9pWHNiI2mJqXwY0gxNlKAroUg==",
           "requires": {
-            "@aws-sdk/middleware-serde": "3.272.0",
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/signature-v4": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/url-parser": "3.272.0",
-            "@aws-sdk/util-config-provider": "3.208.0",
-            "@aws-sdk/util-middleware": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/middleware-serde": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/url-parser": "3.310.0",
+            "@aws-sdk/util-middleware": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/middleware-host-header": {
-          "version": "3.278.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.278.0.tgz",
-          "integrity": "sha512-oTkF3exy89KE8NgSeXFwD+0H0GRKL2qUw92t3caEj7+4KzU/0m3t7NtKlq2NLRtTJhZ/izYRpV536oogLzGm3g==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.310.0.tgz",
+          "integrity": "sha512-QWSA+46/hXorXyWa61ic2K7qZzwHTiwfk2e9mRRjeIRepUgI3qxFjsYqrWtrOGBjmFmq0pYIY8Bb/DCJuQqcoA==",
           "requires": {
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/middleware-logger": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.272.0.tgz",
-          "integrity": "sha512-u2SQ0hWrFwxbxxYMG5uMEgf01pQY5jauK/LYWgGIvuCmFgiyRQQP3oN7kkmsxnS9MWmNmhbyQguX2NY02s5e9w==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.310.0.tgz",
+          "integrity": "sha512-Lurm8XofrASBRnAVtiSNuDSRsRqPNg27RIFLLsLp/pqog9nFJ0vz0kgdb9S5Z+zw83Mm+UlqOe6D8NTUNp4fVg==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/middleware-recursion-detection": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.272.0.tgz",
-          "integrity": "sha512-Gp/eKWeUWVNiiBdmUM2qLkBv+VLSJKoWAO+aKmyxxwjjmWhE0FrfA1NQ1a3g+NGMhRbAfQdaYswRAKsul70ISg==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.310.0.tgz",
+          "integrity": "sha512-SuB75/xk/gyue24gkriTwO2jFd7YcUGZDClQYuRejgbXSa3CO0lWyawQtfLcSSEBp9izrEVXuFH24K1eAft5nQ==",
           "requires": {
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/middleware-retry": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.272.0.tgz",
-          "integrity": "sha512-pCGvHM7C76VbO/dFerH+Vwf7tGv7j+e+eGrvhQ35mRghCtfIou/WMfTZlD1TNee93crrAQQVZKjtW3dMB3WCzg==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.310.0.tgz",
+          "integrity": "sha512-oTPsRy2W4s+dfxbJPW7Km+hHtv/OMsNsVfThAq8DDYKC13qlr1aAyOqGLD+dpBy2aKe7ss517Sy2HcHtHqm7/g==",
           "requires": {
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/service-error-classification": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/util-middleware": "3.272.0",
-            "@aws-sdk/util-retry": "3.272.0",
-            "tslib": "^2.3.1",
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/service-error-classification": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-middleware": "3.310.0",
+            "@aws-sdk/util-retry": "3.310.0",
+            "tslib": "^2.5.0",
             "uuid": "^8.3.2"
           }
         },
         "@aws-sdk/middleware-sdk-sts": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.272.0.tgz",
-          "integrity": "sha512-VvYPg7LrDIjUOWueSzo2wBzcNG7dw+cmzV6zAKaLxf0RC5jeAP4hE0OzDiiZfDrjNghEzgq/V+0NO+LewqYL9Q==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.310.0.tgz",
+          "integrity": "sha512-+5PFwlYNLvLLIfw0ASAoWV/iIF8Zv6R6QGtyP0CclhRSvNjgbQDVnV0g95MC5qvh+GB/Yjlkt8qAjLSPjHfsrQ==",
           "requires": {
-            "@aws-sdk/middleware-signing": "3.272.0",
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/signature-v4": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/middleware-signing": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/middleware-serde": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.272.0.tgz",
-          "integrity": "sha512-kW1uOxgPSwtXPB5rm3QLdWomu42lkYpQL94tM1BjyFOWmBLO2lQhk5a7Dw6HkTozT9a+vxtscLChRa6KZe61Hw==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.310.0.tgz",
+          "integrity": "sha512-RNeeTVWSLTaentUeCgQKZhAl+C6hxtwD78cQWS10UymWpQFwbaxztzKUu4UQS5xA2j6PxwPRRUjqa4jcFjfLsg==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/middleware-signing": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.272.0.tgz",
-          "integrity": "sha512-4LChFK4VAR91X+dupqM8fQqYhFGE0G4Bf9rQlVTgGSbi2KUOmpqXzH0/WKE228nKuEhmH8+Qd2VPSAE2JcyAUA==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.310.0.tgz",
+          "integrity": "sha512-f9mKq+XMdW207Af3hKjdTnpNhdtwqWuvFs/ZyXoOkp/g1MY1O6L23Jy6i52m29LxbT4AuNRG1oKODfXM0vYVjQ==",
           "requires": {
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/signature-v4": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/util-middleware": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/signature-v4": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-middleware": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/middleware-stack": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.272.0.tgz",
-          "integrity": "sha512-jhwhknnPBGhfXAGV5GXUWfEhDFoP/DN8MPCO2yC5OAxyp6oVJ8lTPLkZYMTW5VL0c0eG44dXpF4Ib01V+PlDrQ==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.310.0.tgz",
+          "integrity": "sha512-010O1PD+UAcZVKRvqEusE1KJqN96wwrf6QsqbRM0ywsKQ21NDweaHvEDlds2VHpgmofxkRLRu/IDrlPkKRQrRg==",
           "requires": {
-            "tslib": "^2.3.1"
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/middleware-user-agent": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.272.0.tgz",
-          "integrity": "sha512-Qy7/0fsDJxY5l0bEk7WKDfqb4Os/sCAgFR2zEvrhDtbkhYPf72ysvg/nRUTncmCbo8tOok4SJii2myk8KMfjjw==",
+          "version": "3.319.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.319.0.tgz",
+          "integrity": "sha512-ytaLx2dlR5AdMSne6FuDCISVg8hjyKj+cHU20b2CRA/E/z+XXrLrssp4JrCgizRKPPUep0psMIa22Zd6osTT5Q==",
           "requires": {
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-endpoints": "3.319.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/node-config-provider": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.272.0.tgz",
-          "integrity": "sha512-YYCIBh9g1EQo7hm2l22HX5Yr9RoPQ2RCvhzKvF1n1e8t1QH4iObQrYUtqHG4khcm64Cft8C5MwZmgzHbya5Z6Q==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.310.0.tgz",
+          "integrity": "sha512-T/Pp6htc6hq/Cq+MLNDSyiwWCMVF6GqbBbXKVlO5L8rdHx4sq9xPdoPveZhGWrxvkanjA6eCwUp6E0riBOSVng==",
           "requires": {
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/shared-ini-file-loader": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/shared-ini-file-loader": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/node-http-handler": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.272.0.tgz",
-          "integrity": "sha512-VrW9PjhhngeyYp4yGYPe5S0vgZH6NwU3Po9xAgayUeE37Inr7LS1YteFMHdpgsUUeNXnh7d06CXqHo1XjtqOKA==",
+          "version": "3.321.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.321.1.tgz",
+          "integrity": "sha512-DdQBrtFFDNtzphJIN3s93Vf+qd9LHSzH6WTQRrWoXhTDMHDzSI2Cn+c5KWfk89Nggp/n3+OTwUPQeCiBT5EBuw==",
           "requires": {
-            "@aws-sdk/abort-controller": "3.272.0",
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/querystring-builder": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/abort-controller": "3.310.0",
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/querystring-builder": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/property-provider": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.272.0.tgz",
-          "integrity": "sha512-V1pZTaH5eqpAt8O8CzbItHhOtzIfFuWymvwZFkAtwKuaHpnl7jjrTouV482zoq8AD/fF+VVSshwBKYA7bhidIw==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.310.0.tgz",
+          "integrity": "sha512-3lxDb0akV6BBzmFe4nLPaoliQbAifyWJhuvuDOu7e8NzouvpQXs0275w9LePhhcgjKAEVXUIse05ZW2DLbxo/g==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/protocol-http": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.272.0.tgz",
-          "integrity": "sha512-4JQ54v5Yn08jspNDeHo45CaSn1CvTJqS1Ywgr79eU6jBExtguOWv6LNtwVSBD9X37v88iqaxt8iu1Z3pZZAJeg==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.310.0.tgz",
+          "integrity": "sha512-fgZ1aw/irQtnrsR58pS8ThKOWo57Py3xX6giRvwSgZDEcxHfVzuQjy9yPuV++v04fdmdtgpbGf8WfvAAJ11yXQ==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/querystring-builder": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.272.0.tgz",
-          "integrity": "sha512-ndo++7GkdCj5tBXE6rGcITpSpZS4PfyV38wntGYAlj9liL1omk3bLZRY6uzqqkJpVHqbg2fD7O2qHNItzZgqhw==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.310.0.tgz",
+          "integrity": "sha512-ZHH8GV/80+pWGo7DzsvwvXR5xVxUHXUvPJPFAkhr6nCf78igdoF8gR10ScFoEKbtEapoNTaZlKHPXxpD8aPG7A==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/util-uri-escape": "3.201.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-uri-escape": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/querystring-parser": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.272.0.tgz",
-          "integrity": "sha512-5oS4/9n6N1LZW9tI3qq/0GnCuWoOXRgcHVB+AJLRBvDbEe+GI+C/xK1tKLsfpDNgsQJHc4IPQoIt4megyZ/1+A==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.310.0.tgz",
+          "integrity": "sha512-YkIznoP6lsiIUHinx++/lbb3tlMURGGqMpo0Pnn32zYzGrJXA6eC3D0as2EcMjo55onTfuLcIiX4qzXes2MYOA==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/service-error-classification": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.272.0.tgz",
-          "integrity": "sha512-REoltM1LK9byyIufLqx9znhSolPcHQgVHIA2S0zu5sdt5qER4OubkLAXuo4MBbisUTmh8VOOvIyUb5ijZCXq1w=="
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.310.0.tgz",
+          "integrity": "sha512-PuyC7k3qfIKeH2LCnDwbttMOKq3qAx4buvg0yfnJtQOz6t1AR8gsnAq0CjKXXyfkXwNKWTqCpE6lVNUIkXgsMw=="
         },
         "@aws-sdk/shared-ini-file-loader": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.272.0.tgz",
-          "integrity": "sha512-lzFPohp5sy2XvwFjZIzLVCRpC0i5cwBiaXmFzXYQZJm6FSCszHO4ax+m9yrtlyVFF/2YPWl+/bzNthy4aJtseA==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.310.0.tgz",
+          "integrity": "sha512-N0q9pG0xSjQwc690YQND5bofm+4nfUviQ/Ppgan2kU6aU0WUq8KwgHJBto/YEEI+VlrME30jZJnxtOvcZJc2XA==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/signature-v4": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.272.0.tgz",
-          "integrity": "sha512-pWxnHG1NqJWMwlhJ6NHNiUikOL00DHROmxah6krJPMPq4I3am2KY2Rs/8ouWhnEXKaHAv4EQhSALJ+7Mq5S4/A==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.310.0.tgz",
+          "integrity": "sha512-1M60P1ZBNAjCFv9sYW29OF6okktaeibWyW3lMXqzoHF70lHBZh+838iUchznXUA5FLabfn4jBFWMRxlAXJUY2Q==",
           "requires": {
-            "@aws-sdk/is-array-buffer": "3.201.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/util-hex-encoding": "3.201.0",
-            "@aws-sdk/util-middleware": "3.272.0",
-            "@aws-sdk/util-uri-escape": "3.201.0",
-            "@aws-sdk/util-utf8": "3.254.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/is-array-buffer": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-hex-encoding": "3.310.0",
+            "@aws-sdk/util-middleware": "3.310.0",
+            "@aws-sdk/util-uri-escape": "3.310.0",
+            "@aws-sdk/util-utf8": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/smithy-client": {
-          "version": "3.279.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.279.0.tgz",
-          "integrity": "sha512-ZcYWUQDGAYN6NXRpJuSn46PetrpPCA6TrDVwP9+3pERzTXZ66npXoG2XhHjNrOXy/Ted5A3OxKrM4/zLu9tK3A==",
+          "version": "3.316.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.316.0.tgz",
+          "integrity": "sha512-6YXOKbRnXeS8r8RWzuL6JMBolDYM5Wa4fD/VY6x/wK78i2xErHOvqzHgyyeLI1MMw4uqyd4wRNJNWC9TMPduXw==",
           "requires": {
-            "@aws-sdk/middleware-stack": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/middleware-stack": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/token-providers": {
-          "version": "3.281.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.281.0.tgz",
-          "integrity": "sha512-36Vg/F6Edm7qdjcTeNVON+sK2edgHhmhTtAEjWcuUk5AX/Et+Ate/A2N8HD3nxwlAcgidfnBC9SHYJatbhcEnQ==",
+          "version": "3.321.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.321.1.tgz",
+          "integrity": "sha512-I1sXS4qXirSvgvrOIPf+e1D7GvC83DdeyMxHZvuhHgeMCqDAzToS8OLxOX0enN9xZRHWAQYja8xyeGbDL2I0Zw==",
           "requires": {
-            "@aws-sdk/client-sso-oidc": "3.281.0",
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/shared-ini-file-loader": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/client-sso-oidc": "3.321.1",
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/shared-ini-file-loader": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/types": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.272.0.tgz",
-          "integrity": "sha512-MmmL6vxMGP5Bsi+4wRx4mxYlU/LX6M0noOXrDh/x5FfG7/4ZOar/nDxqDadhJtNM88cuWVHZWY59P54JzkGWmA==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.310.0.tgz",
+          "integrity": "sha512-j8eamQJ7YcIhw7fneUfs8LYl3t01k4uHi4ZDmNRgtbmbmTTG3FZc2MotStZnp3nZB6vLiPF1o5aoJxWVvkzS6A==",
           "requires": {
-            "tslib": "^2.3.1"
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/url-parser": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.272.0.tgz",
-          "integrity": "sha512-vX/Tx02PlnQ/Kgtf5TnrNDHPNbY+amLZjW0Z1d9vzAvSZhQ4i9Y18yxoRDIaDTCNVRDjdhV8iuctW+05PB5JtQ==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.310.0.tgz",
+          "integrity": "sha512-mCLnCaSB9rQvAgx33u0DujLvr4d5yEm/W5r789GblwwQnlNXedVu50QRizMLTpltYWyAUoXjJgQnJHmJMaKXhw==",
           "requires": {
-            "@aws-sdk/querystring-parser": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/querystring-parser": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-base64": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
+          "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-body-length-browser": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
+          "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
+          "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
+          "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-config-provider": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
+          "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
+          "requires": {
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/util-defaults-mode-browser": {
-          "version": "3.279.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.279.0.tgz",
-          "integrity": "sha512-RnchYRrpapTT5Hu23LOfk6e8RMVq0kUzho6xA6TJj1a4uGxkcRMvgzPipCq1P5uHu0mrkQBg9pGPEVNOUs38/Q==",
+          "version": "3.316.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.316.0.tgz",
+          "integrity": "sha512-6FSqLhYmaihtH2n1s4b2rlLW0ABU8N6VZIfzLfe2ING4PF0MzfaMMhnTFUHVXfKCVGoR8yP6iyFTRCyHGVEL1w==",
           "requires": {
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
             "bowser": "^2.11.0",
-            "tslib": "^2.3.1"
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/util-defaults-mode-node": {
-          "version": "3.279.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.279.0.tgz",
-          "integrity": "sha512-A2NB10xReWC+GSnOivKGZ9rnljIZdEP8WMCQQEnA6DJNI19AUFF/O9QJ9y+cHGLKEms7jH86Y99wShdpzAK+Jw==",
+          "version": "3.316.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.316.0.tgz",
+          "integrity": "sha512-dkYy10hdjPSScXXvnjGpZpnJxllkb6ICHgLMwZ4JczLHhPM12T/4PQ758YN8HS+muiYDGX1Bl2z1jd/bMcewBQ==",
           "requires": {
-            "@aws-sdk/config-resolver": "3.272.0",
-            "@aws-sdk/credential-provider-imds": "3.272.0",
-            "@aws-sdk/node-config-provider": "3.272.0",
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/config-resolver": "3.310.0",
+            "@aws-sdk/credential-provider-imds": "3.310.0",
+            "@aws-sdk/node-config-provider": "3.310.0",
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/util-endpoints": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.272.0.tgz",
-          "integrity": "sha512-c4MPUaJt2G6gGpoiwIOqDfUa98c1J63RpYvf/spQEKOtC/tF5Gfqlxuq8FnAl5lHnrqj1B9ZXLLxFhHtDR0IiQ==",
+          "version": "3.319.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.319.0.tgz",
+          "integrity": "sha512-3I64UMoYA2e2++oOUJXRcFtYLpLylnZFRltWfPo1B3dLlf+MIWat9djT+mMus+hW1ntLsvAIVu1hLVePJC0gvw==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
+          "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
+          "requires": {
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/util-middleware": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.272.0.tgz",
-          "integrity": "sha512-Abw8m30arbwxqmeMMha5J11ESpHUNmCeSqSzE8/C4B8jZQtHY4kq7f+upzcNIQ11lsd+uzBEzNG3+dDRi0XOJQ==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.310.0.tgz",
+          "integrity": "sha512-FTSUKL/eRb9X6uEZClrTe27QFXUNNp7fxYrPndZwk1hlaOP5ix+MIHBcI7pIiiY/JPfOUmPyZOu+HetlFXjWog==",
           "requires": {
-            "tslib": "^2.3.1"
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/util-retry": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.272.0.tgz",
-          "integrity": "sha512-Ngha5414LR4gRHURVKC9ZYXsEJhMkm+SJ+44wlzOhavglfdcKKPUsibz5cKY1jpUV7oKECwaxHWpBB8r6h+hOg==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.310.0.tgz",
+          "integrity": "sha512-FwWGhCBLfoivTMUHu1LIn4NjrN9JLJ/aX5aZmbcPIOhZVFJj638j0qDgZXyfvVqBuBZh7M8kGq0Oahy3dp69OA==",
           "requires": {
-            "@aws-sdk/service-error-classification": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/service-error-classification": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
+          "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
+          "requires": {
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/util-user-agent-browser": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.272.0.tgz",
-          "integrity": "sha512-Lp5QX5bH6uuwBlIdr7w7OAcAI50ttyskb++yUr9i+SPvj6RI2dsfIBaK4mDg1qUdM5LeUdvIyqwj3XHjFKAAvA==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.310.0.tgz",
+          "integrity": "sha512-yU/4QnHHuQ5z3vsUqMQVfYLbZGYwpYblPiuZx4Zo9+x0PBkNjYMqctdDcrpoH9Z2xZiDN16AmQGK1tix117ZKw==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
+            "@aws-sdk/types": "3.310.0",
             "bowser": "^2.11.0",
-            "tslib": "^2.3.1"
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/util-user-agent-node": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.272.0.tgz",
-          "integrity": "sha512-ljK+R3l+Q1LIHrcR+Knhk0rmcSkfFadZ8V+crEGpABf/QUQRg7NkZMsoe814tfBO5F7tMxo8wwwSdaVNNHtoRA==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.310.0.tgz",
+          "integrity": "sha512-Ra3pEl+Gn2BpeE7KiDGpi4zj7WJXZA5GXnGo3mjbi9+Y3zrbuhJAbdZO3mO/o7xDgMC6ph4xCTbaSGzU6b6EDg==",
           "requires": {
-            "@aws-sdk/node-config-provider": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/node-config-provider": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "fast-xml-parser": {
@@ -24205,6 +25029,15 @@
           "requires": {
             "tslib": "^2.3.1"
           }
+        },
+        "@aws-sdk/util-utf8": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.254.0.tgz",
+          "integrity": "sha512-14Kso/eIt5/qfIBmhEL9L1IfyUqswjSTqO2mY7KOzUZ9SZbwn3rpxmtkhmATkRjD7XIlLKaxBkI7tU9Zjzj8Kw==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.208.0",
+            "tslib": "^2.3.1"
+          }
         }
       }
     },
@@ -24240,6 +25073,15 @@
           "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.272.0.tgz",
           "integrity": "sha512-MmmL6vxMGP5Bsi+4wRx4mxYlU/LX6M0noOXrDh/x5FfG7/4ZOar/nDxqDadhJtNM88cuWVHZWY59P54JzkGWmA==",
           "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-utf8": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.254.0.tgz",
+          "integrity": "sha512-14Kso/eIt5/qfIBmhEL9L1IfyUqswjSTqO2mY7KOzUZ9SZbwn3rpxmtkhmATkRjD7XIlLKaxBkI7tU9Zjzj8Kw==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.208.0",
             "tslib": "^2.3.1"
           }
         }
@@ -24358,6 +25200,15 @@
           "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.272.0.tgz",
           "integrity": "sha512-MmmL6vxMGP5Bsi+4wRx4mxYlU/LX6M0noOXrDh/x5FfG7/4ZOar/nDxqDadhJtNM88cuWVHZWY59P54JzkGWmA==",
           "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-utf8": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.254.0.tgz",
+          "integrity": "sha512-14Kso/eIt5/qfIBmhEL9L1IfyUqswjSTqO2mY7KOzUZ9SZbwn3rpxmtkhmATkRjD7XIlLKaxBkI7tU9Zjzj8Kw==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.208.0",
             "tslib": "^2.3.1"
           }
         }
@@ -24664,6 +25515,15 @@
           "requires": {
             "tslib": "^2.3.1"
           }
+        },
+        "@aws-sdk/util-utf8": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.254.0.tgz",
+          "integrity": "sha512-14Kso/eIt5/qfIBmhEL9L1IfyUqswjSTqO2mY7KOzUZ9SZbwn3rpxmtkhmATkRjD7XIlLKaxBkI7tU9Zjzj8Kw==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.208.0",
+            "tslib": "^2.3.1"
+          }
         }
       }
     },
@@ -24824,116 +25684,183 @@
       }
     },
     "@aws-sdk/util-stream-browser": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.272.0.tgz",
-      "integrity": "sha512-vD514YffKxBjV/erjUNgkXcb/mzXAz3uk/KUFMXsodo3cA4Z8WxL4P0p1O09FVuJlNa0gZ8mhFPNzNOekh31GA==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.310.0.tgz",
+      "integrity": "sha512-bysXZHwFwvbqOTCScCdCnoLk1K3GCo0HRIYEZuL7O7MHrQmfaYRXcaft/p22+GUv9VeFXS/eJJZ5r4u32az94w==",
       "requires": {
-        "@aws-sdk/fetch-http-handler": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/fetch-http-handler": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "dependencies": {
         "@aws-sdk/fetch-http-handler": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.272.0.tgz",
-          "integrity": "sha512-1Qhm9e0RbS1Xf4CZqUbQyUMkDLd7GrsRXWIvm9b86/vgeV8/WnjO3CMue9D51nYgcyQORhYXv6uVjAYCWbUExA==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.310.0.tgz",
+          "integrity": "sha512-Bi9vIwzdkw1zMcvi/zGzlWS9KfIEnAq4NNhsnCxbQ4OoIRU9wvU+WGZdBBhxg0ZxZmpp1j1aZhU53lLjA07MHw==",
           "requires": {
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/querystring-builder": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/querystring-builder": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-base64": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
+          "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
+          "requires": {
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/protocol-http": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.272.0.tgz",
-          "integrity": "sha512-4JQ54v5Yn08jspNDeHo45CaSn1CvTJqS1Ywgr79eU6jBExtguOWv6LNtwVSBD9X37v88iqaxt8iu1Z3pZZAJeg==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.310.0.tgz",
+          "integrity": "sha512-fgZ1aw/irQtnrsR58pS8ThKOWo57Py3xX6giRvwSgZDEcxHfVzuQjy9yPuV++v04fdmdtgpbGf8WfvAAJ11yXQ==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/querystring-builder": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.272.0.tgz",
-          "integrity": "sha512-ndo++7GkdCj5tBXE6rGcITpSpZS4PfyV38wntGYAlj9liL1omk3bLZRY6uzqqkJpVHqbg2fD7O2qHNItzZgqhw==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.310.0.tgz",
+          "integrity": "sha512-ZHH8GV/80+pWGo7DzsvwvXR5xVxUHXUvPJPFAkhr6nCf78igdoF8gR10ScFoEKbtEapoNTaZlKHPXxpD8aPG7A==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/util-uri-escape": "3.201.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-uri-escape": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/types": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.272.0.tgz",
-          "integrity": "sha512-MmmL6vxMGP5Bsi+4wRx4mxYlU/LX6M0noOXrDh/x5FfG7/4ZOar/nDxqDadhJtNM88cuWVHZWY59P54JzkGWmA==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.310.0.tgz",
+          "integrity": "sha512-j8eamQJ7YcIhw7fneUfs8LYl3t01k4uHi4ZDmNRgtbmbmTTG3FZc2MotStZnp3nZB6vLiPF1o5aoJxWVvkzS6A==",
           "requires": {
-            "tslib": "^2.3.1"
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-base64": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
+          "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
+          "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
+          "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
+          "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
+          "requires": {
+            "tslib": "^2.5.0"
           }
         }
       }
     },
     "@aws-sdk/util-stream-node": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.272.0.tgz",
-      "integrity": "sha512-s7dGeM1ImzihqBKgrpaeZokLnPUk3H4Et5oiM+t+TpRxotXTecJPyuD0p76HRgO8KSXfVT5Nxw/FoHXqj1fiMg==",
+      "version": "3.321.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.321.1.tgz",
+      "integrity": "sha512-jvfff1zeA8q16hQWSC0BGwcHJPCwoh+bwiuAjihfl9q1tFLYuqaTzJzzkL1bntUsbW+y/ac5DO7fWcYPq0jWkw==",
       "requires": {
-        "@aws-sdk/node-http-handler": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/node-http-handler": "3.321.1",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "dependencies": {
         "@aws-sdk/abort-controller": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.272.0.tgz",
-          "integrity": "sha512-s2TV3phapcTwZNr4qLxbfuQuE9ZMP4RoJdkvRRCkKdm6jslsWLJf2Zlcxti/23hOlINUMYv2iXE2pftIgWGdpg==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.310.0.tgz",
+          "integrity": "sha512-v1zrRQxDLA1MdPim159Vx/CPHqsB4uybSxRi1CnfHO5ZjHryx3a5htW2gdGAykVCul40+yJXvfpufMrELVxH+g==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
+          "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
+          "requires": {
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/node-http-handler": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.272.0.tgz",
-          "integrity": "sha512-VrW9PjhhngeyYp4yGYPe5S0vgZH6NwU3Po9xAgayUeE37Inr7LS1YteFMHdpgsUUeNXnh7d06CXqHo1XjtqOKA==",
+          "version": "3.321.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.321.1.tgz",
+          "integrity": "sha512-DdQBrtFFDNtzphJIN3s93Vf+qd9LHSzH6WTQRrWoXhTDMHDzSI2Cn+c5KWfk89Nggp/n3+OTwUPQeCiBT5EBuw==",
           "requires": {
-            "@aws-sdk/abort-controller": "3.272.0",
-            "@aws-sdk/protocol-http": "3.272.0",
-            "@aws-sdk/querystring-builder": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/abort-controller": "3.310.0",
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/querystring-builder": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/protocol-http": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.272.0.tgz",
-          "integrity": "sha512-4JQ54v5Yn08jspNDeHo45CaSn1CvTJqS1Ywgr79eU6jBExtguOWv6LNtwVSBD9X37v88iqaxt8iu1Z3pZZAJeg==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.310.0.tgz",
+          "integrity": "sha512-fgZ1aw/irQtnrsR58pS8ThKOWo57Py3xX6giRvwSgZDEcxHfVzuQjy9yPuV++v04fdmdtgpbGf8WfvAAJ11yXQ==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/querystring-builder": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.272.0.tgz",
-          "integrity": "sha512-ndo++7GkdCj5tBXE6rGcITpSpZS4PfyV38wntGYAlj9liL1omk3bLZRY6uzqqkJpVHqbg2fD7O2qHNItzZgqhw==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.310.0.tgz",
+          "integrity": "sha512-ZHH8GV/80+pWGo7DzsvwvXR5xVxUHXUvPJPFAkhr6nCf78igdoF8gR10ScFoEKbtEapoNTaZlKHPXxpD8aPG7A==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/util-uri-escape": "3.201.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-uri-escape": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/types": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.272.0.tgz",
-          "integrity": "sha512-MmmL6vxMGP5Bsi+4wRx4mxYlU/LX6M0noOXrDh/x5FfG7/4ZOar/nDxqDadhJtNM88cuWVHZWY59P54JzkGWmA==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.310.0.tgz",
+          "integrity": "sha512-j8eamQJ7YcIhw7fneUfs8LYl3t01k4uHi4ZDmNRgtbmbmTTG3FZc2MotStZnp3nZB6vLiPF1o5aoJxWVvkzS6A==",
           "requires": {
-            "tslib": "^2.3.1"
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
+          "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
+          "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
+          "requires": {
+            "tslib": "^2.5.0"
           }
         }
       }
@@ -24967,12 +25894,31 @@
       }
     },
     "@aws-sdk/util-utf8": {
-      "version": "3.254.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.254.0.tgz",
-      "integrity": "sha512-14Kso/eIt5/qfIBmhEL9L1IfyUqswjSTqO2mY7KOzUZ9SZbwn3rpxmtkhmATkRjD7XIlLKaxBkI7tU9Zjzj8Kw==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.310.0.tgz",
+      "integrity": "sha512-DnLfFT8uCO22uOJc0pt0DsSNau1GTisngBCDw8jQuWT5CqogMJu4b/uXmwEqfj8B3GX6Xsz8zOd6JpRlPftQoA==",
       "requires": {
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
+          "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
+          "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        }
       }
     },
     "@aws-sdk/util-utf8-browser": {
@@ -24993,30 +25939,30 @@
       }
     },
     "@aws-sdk/util-waiter": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.272.0.tgz",
-      "integrity": "sha512-N25/XsJ2wkPh1EgkFyb/GRgfHDityScfD49Hk1AwJWpfetzgkcEtWdeW4IuPymXlSKhrm5L+SBw49USxo9kBag==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.310.0.tgz",
+      "integrity": "sha512-AV5j3guH/Y4REu+Qh3eXQU9igljHuU4XjX2sADAgf54C0kkhcCCkkiuzk3IsX089nyJCqIcj5idbjdvpnH88Vw==",
       "requires": {
-        "@aws-sdk/abort-controller": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/abort-controller": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "dependencies": {
         "@aws-sdk/abort-controller": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.272.0.tgz",
-          "integrity": "sha512-s2TV3phapcTwZNr4qLxbfuQuE9ZMP4RoJdkvRRCkKdm6jslsWLJf2Zlcxti/23hOlINUMYv2iXE2pftIgWGdpg==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.310.0.tgz",
+          "integrity": "sha512-v1zrRQxDLA1MdPim159Vx/CPHqsB4uybSxRi1CnfHO5ZjHryx3a5htW2gdGAykVCul40+yJXvfpufMrELVxH+g==",
           "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
           }
         },
         "@aws-sdk/types": {
-          "version": "3.272.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.272.0.tgz",
-          "integrity": "sha512-MmmL6vxMGP5Bsi+4wRx4mxYlU/LX6M0noOXrDh/x5FfG7/4ZOar/nDxqDadhJtNM88cuWVHZWY59P54JzkGWmA==",
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.310.0.tgz",
+          "integrity": "sha512-j8eamQJ7YcIhw7fneUfs8LYl3t01k4uHi4ZDmNRgtbmbmTTG3FZc2MotStZnp3nZB6vLiPF1o5aoJxWVvkzS6A==",
           "requires": {
-            "tslib": "^2.3.1"
+            "tslib": "^2.5.0"
           }
         }
       }
@@ -25036,17 +25982,18 @@
       "requires": {}
     },
     "@awsui/component-toolkit": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@awsui/component-toolkit/-/component-toolkit-1.0.0-beta.4.tgz",
-      "integrity": "sha512-6rxgDemVPS2OorC48fGjcnVBEdAqBRoWgrTCh1mClNfuHwioHxyICBUqxFCUxsIN8HHa/iAG9VFA+e4uoGN24g==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@awsui/component-toolkit/-/component-toolkit-1.0.0-beta.5.tgz",
+      "integrity": "sha512-sa45TYaMkl95eBl6MsRLJwJFKLxOfKrfi5ki+eSY+Z1AKkJLRAvMkbaw7g/BaXdsrCmgjElmoQshUMPzfDtMzQ==",
       "requires": {
-        "@juggle/resize-observer": "^3.3.1"
+        "@juggle/resize-observer": "^3.3.1",
+        "tslib": "^2.3.1"
       }
     },
     "@awsui/components-react": {
-      "version": "3.0.820",
-      "resolved": "https://registry.npmjs.org/@awsui/components-react/-/components-react-3.0.820.tgz",
-      "integrity": "sha512-MRiXcRuJcuqixQfDr/ctFGPchdtel2zcHCyeL/SZFJIeVJ0yCFSsnQdax6GKZ70qNWgqcXtg+k/qm104PQb+TA==",
+      "version": "3.0.821",
+      "resolved": "https://registry.npmjs.org/@awsui/components-react/-/components-react-3.0.821.tgz",
+      "integrity": "sha512-IZcsc1FEBZS/nz6ob24Xg6GB9M5qB9ygexu2USODtHgXsFEuzOixHBTABJMP9rwupTOezF9ZuL4EGQZg5eb/zQ==",
       "requires": {
         "@awsui/collection-hooks": "^1.0.0",
         "@awsui/component-toolkit": "^1.0.0-beta",
@@ -26327,17 +27274,18 @@
       "requires": {}
     },
     "@cloudscape-design/component-toolkit": {
-      "version": "1.0.0-beta.13",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/component-toolkit/-/component-toolkit-1.0.0-beta.13.tgz",
-      "integrity": "sha512-Sl4TjLZnLxeLBB63NZlIk3J1M4wFUnRtljI4PGfFVj+VgUia/DseBkgNguo7xnYIVF21wVaAHKsmrxPxfxDTaQ==",
+      "version": "1.0.0-beta.14",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/component-toolkit/-/component-toolkit-1.0.0-beta.14.tgz",
+      "integrity": "sha512-FUncISDyZJMOuuFDFzzXUdrew+deTpF7oJeox34b9Xm69L7fJYQV5mOkKckFW5/lnE52n3pENfU5hLb+ic+baw==",
       "requires": {
-        "@juggle/resize-observer": "^3.3.1"
+        "@juggle/resize-observer": "^3.3.1",
+        "tslib": "^2.3.1"
       }
     },
     "@cloudscape-design/components": {
-      "version": "3.0.275",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/components/-/components-3.0.275.tgz",
-      "integrity": "sha512-6bXCdXmvZcbCGlQYj2xaIDpmJg0JW/uF6YCYSLChMcZZ7QoxrW61eb2EiAy8kv6Cau83/HosJAc9+skZolNMbQ==",
+      "version": "3.0.276",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/components/-/components-3.0.276.tgz",
+      "integrity": "sha512-rC+ZFAvCAaHdPxCBkg5ydprndEG6lGdTMIYawHpeivpnPIU9muUlhh/Psp5CTdSyY992r6Al4NveSuIwtKr9Yw==",
       "requires": {
         "@cloudscape-design/collection-hooks": "^1.0.0",
         "@cloudscape-design/component-toolkit": "^1.0.0-beta",
@@ -26808,27 +27756,27 @@
       }
     },
     "@iot-app-kit/components": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@iot-app-kit/components/-/components-5.5.1.tgz",
-      "integrity": "sha512-UpAj7PJeni6+5VDvw5396cugCI+jepO3+QhMsJkmPhpAj1nZEEFGrg/kShUh4DRls6bpgkxtdwn15Ooawt9akQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@iot-app-kit/components/-/components-5.7.0.tgz",
+      "integrity": "sha512-YsfAIzSigIw7DNmj7IfEZsjGzdZkhLCQdymAtDHlXQL09R8B+gFmz7yf1UY6nnuV1w61uRcKFXGYiImj0EA+Bw==",
       "requires": {
         "@awsui/collection-hooks": "^1.0.0",
         "@awsui/components-react": "^3.0.0",
         "@awsui/design-tokens": "^3.0.0",
-        "@iot-app-kit/core": "5.5.1",
-        "@iot-app-kit/related-table": "5.5.1",
+        "@iot-app-kit/core": "5.7.0",
+        "@iot-app-kit/related-table": "5.7.0",
         "@stencil/core": "^2.7.0",
         "@synchro-charts/core": "7.2.0",
         "styled-components": "^5.3.9"
       }
     },
     "@iot-app-kit/core": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@iot-app-kit/core/-/core-5.5.1.tgz",
-      "integrity": "sha512-9pDC4bbf1H+tkXlCl2yN9cAHXPoOkN/ocxfkv9VDKwrqfPyy2dM4g1CDHhELGRgmCVTs9RFCgNPVR8skX2yOvQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@iot-app-kit/core/-/core-5.7.0.tgz",
+      "integrity": "sha512-aqUbqNsQk+BnS8mdmCqD/68Q9OUKZhdEmFI3F0+HSPZjIzOs/Qe5m6e/OF+K/ornWtDtj6fexKuZsTlj8FoNjA==",
       "requires": {
-        "@aws-sdk/client-iotsitewise": "3.281.0",
-        "d3-array": "^3.2.2",
+        "@aws-sdk/client-iotsitewise": "3.319.0",
+        "d3-array": "^3.2.3",
         "intervals-fn": "^3.0.3",
         "parse-duration": "^1.0.3",
         "redux": "^4.2.1",
@@ -26844,30 +27792,30 @@
       }
     },
     "@iot-app-kit/core-util": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@iot-app-kit/core-util/-/core-util-5.5.1.tgz",
-      "integrity": "sha512-iP9tFc0lQZbZ6QHDnZUjcdY8BLo/E2ab8uaul9nL2zFh7Noq2hAJX/HD8LG19YVn8AAQoAZkHkerq0JQ1hiGVQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@iot-app-kit/core-util/-/core-util-5.7.0.tgz",
+      "integrity": "sha512-BmKuUa+c5p33w9DLMuiwKf/p0b5rvN7ihuTEcWgmokal7AMeM+opXRVTS6TFqXj0mnJAMmnBr+VC9b8yEvSwsw==",
       "requires": {
-        "@aws-sdk/client-iot-events": "3.281.0",
-        "@aws-sdk/client-iotsitewise": "3.281.0"
+        "@aws-sdk/client-iot-events": "3.319.0",
+        "@aws-sdk/client-iotsitewise": "3.319.0"
       }
     },
     "@iot-app-kit/react-components": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@iot-app-kit/react-components/-/react-components-5.5.1.tgz",
-      "integrity": "sha512-fkZkCjW5yvETAVDYdBniXaWjP2zngxKMlnYpVbZFO17MAxr8Qr4wHhjdWFxA28DxM42+aAsddqtgUfrVQCiaeQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@iot-app-kit/react-components/-/react-components-5.7.0.tgz",
+      "integrity": "sha512-sMvBhgu9o2bABWrdxf3m01mr3lmSKrRqbHOX1KbStlVBMfM/I4Vo8OITuOurmrUpUY8IhtgAk1Yxnia18QUKhg==",
       "requires": {
         "@cloudscape-design/collection-hooks": "^1.0.19",
         "@cloudscape-design/components": "^3.0.244",
         "@cloudscape-design/design-tokens": "^3.0.9",
-        "@iot-app-kit/charts": "^1.8.1",
-        "@iot-app-kit/charts-core": "^1.8.1",
-        "@iot-app-kit/components": "5.5.1",
-        "@iot-app-kit/core": "5.5.1",
-        "@iot-app-kit/core-util": "5.5.1",
-        "@iot-app-kit/source-iottwinmaker": "5.5.1",
+        "@iot-app-kit/charts": "^1.8.4",
+        "@iot-app-kit/charts-core": "^1.8.4",
+        "@iot-app-kit/components": "5.7.0",
+        "@iot-app-kit/core": "5.7.0",
+        "@iot-app-kit/core-util": "5.7.0",
+        "@iot-app-kit/source-iottwinmaker": "5.7.0",
         "color": "^4.2.3",
-        "d3-array": "^3.2.2",
+        "d3-array": "^3.2.3",
         "d3-shape": "^3.2.0",
         "dompurify": "2.3.4",
         "lodash.omitby": "^4.6.0",
@@ -26885,9 +27833,9 @@
       }
     },
     "@iot-app-kit/related-table": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@iot-app-kit/related-table/-/related-table-5.5.1.tgz",
-      "integrity": "sha512-E7hIQNUNTflTTRF83guOTasOBa2gyAIkOIUtv/6FseOFOcWDSf9Xykv/jHOQeH5JgIt0BJtwvkIA3kUAq+Xwdw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@iot-app-kit/related-table/-/related-table-5.7.0.tgz",
+      "integrity": "sha512-GkaJHWopb1etDOxkydcjey0yyb2y25IHnyisaeY+q6qxFHTaL+FK315nQYnEQhBpnkdlEtwWUhITyq/+Y1sBNQ==",
       "requires": {
         "uuid": "^9.0.0"
       },
@@ -26900,19 +27848,19 @@
       }
     },
     "@iot-app-kit/scene-composer": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@iot-app-kit/scene-composer/-/scene-composer-5.5.1.tgz",
-      "integrity": "sha512-KYZ8Ouiw/ZKXnLMFU8t0qfHt8onspXkUmmalGAqKZJtX7+NtzxYe32B9GlRldrItxLOlrAXJRbIqnkalvkAQkw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@iot-app-kit/scene-composer/-/scene-composer-5.7.0.tgz",
+      "integrity": "sha512-oRFdkcfVpfATr9OjzipvIRiRj1n4f81ArFeB9y6RwSMNS6/Y30/Z+dtCni22B3+YlaCoUZheJCoQfWqJxxBHNA==",
       "requires": {
         "@awsui/collection-hooks": "^1.0.0",
         "@awsui/components-react": "^3.0.0",
         "@awsui/design-tokens": "^3.0.0",
         "@awsui/global-styles": "^1.0.12",
         "@formatjs/ts-transformer": "3.9.11",
-        "@iot-app-kit/core": "5.5.1",
-        "@iot-app-kit/related-table": "5.5.1",
-        "@matterport/r3f": "^0.1.0",
-        "@matterport/webcomponent": "^0.1.2",
+        "@iot-app-kit/core": "5.7.0",
+        "@iot-app-kit/related-table": "5.7.0",
+        "@matterport/r3f": "^0.2.1",
+        "@matterport/webcomponent": "^0.1.21",
         "@react-three/drei": "9.56.27",
         "@react-three/fiber": "^8.11.5",
         "@react-three/postprocessing": "2.6.2",
@@ -26929,8 +27877,8 @@
         "postprocessing": "6.28.5",
         "react-color": "^2.19.3",
         "react-dnd": "^16.0.1",
-        "react-dnd-html5-backend": "^15.1.3",
-        "react-markdown": "^8.0.5",
+        "react-dnd-html5-backend": "^16.0.1",
+        "react-markdown": "^8.0.7",
         "rehype-sanitize": "^5.0.1",
         "stats.js": "^0.17.0",
         "string-to-arraybuffer": "1.0.2",
@@ -26938,7 +27886,7 @@
         "three": "0.146.0",
         "three-mesh-bvh": "0.5.15",
         "three-stdlib": "2.17.3",
-        "ts-custom-error": "^3.2.0",
+        "ts-custom-error": "^3.3.1",
         "tslib": "^2.3.1",
         "typescript": "^4.5",
         "zundo": "1.1.0",
@@ -26958,18 +27906,18 @@
       }
     },
     "@iot-app-kit/source-iottwinmaker": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@iot-app-kit/source-iottwinmaker/-/source-iottwinmaker-5.5.1.tgz",
-      "integrity": "sha512-ZTMOPKS7Pu3Rnon6V3qmjsACQ6T40iwRyVam2Pq+uV6UrtmRRWixTHLorJLmaAmfEyVc+lTO6Pv34bSJ+q7eLg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@iot-app-kit/source-iottwinmaker/-/source-iottwinmaker-5.7.0.tgz",
+      "integrity": "sha512-2OaNPEFBHH4ZzkpX1KFN4nxd00XNTCHzrlZeyvcqP9CL38dDL1E1VS8dw+zjrH3ZXhqioi436c4ijQ3aXNzU+g==",
       "requires": {
-        "@aws-sdk/client-iotsitewise": "3.281.0",
+        "@aws-sdk/client-iotsitewise": "3.319.0",
         "@aws-sdk/client-iottwinmaker": "3.297.0",
         "@aws-sdk/client-kinesis-video": "3.281.0",
-        "@aws-sdk/client-kinesis-video-archived-media": "3.281.0",
+        "@aws-sdk/client-kinesis-video-archived-media": "3.321.1",
         "@aws-sdk/client-s3": "3.281.0",
-        "@aws-sdk/client-secrets-manager": "3.281.0",
+        "@aws-sdk/client-secrets-manager": "3.321.1",
         "@aws-sdk/url-parser": "3.289.0",
-        "@iot-app-kit/core": "5.5.1",
+        "@iot-app-kit/core": "5.7.0",
         "lodash": "^4.17.21",
         "rxjs": "^7.8.0"
       },
@@ -27992,9 +28940,9 @@
       }
     },
     "@matterport/r3f": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@matterport/r3f/-/r3f-0.1.0.tgz",
-      "integrity": "sha512-/aW9qngBygBLq1QpUUI0PFrEbeQur5kFGf591lr3VN1mDHtmQgVSvTOJAri91gtqzggrXYlq4mwMw4mzjaXAgA==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@matterport/r3f/-/r3f-0.2.3.tgz",
+      "integrity": "sha512-HMz0msMyCkBPZ+uUY2HJ3Rm0e62ll2uCgOYH7zwWrWaQI3hPtJfJr5cfBsNKwh9vcHgj+Q8c2AuTh4eJnp8M2A==",
       "requires": {}
     },
     "@matterport/webcomponent": {
@@ -30219,9 +31167,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.4.387",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.387.tgz",
-      "integrity": "sha512-tutLf+alr1/0YqJwKPdstVvDLmxmLb5xNyDLNS0RZmenHcEYk9qKfpKDCVZEKJ00JVbnayJm1MZAbYhYDFpcOw==",
+      "version": "1.4.388",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.388.tgz",
+      "integrity": "sha512-xZ0y4zjWZgp65okzwwt00f2rYibkFPHUv9qBz+Vzn8cB9UXIo9Zc6Dw81LJYhhNt0G/vR1OJEfStZ49NKl0YxQ==",
       "dev": true
     },
     "emojis-list": {
@@ -32636,33 +33584,11 @@
       }
     },
     "react-dnd-html5-backend": {
-      "version": "15.1.3",
-      "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-15.1.3.tgz",
-      "integrity": "sha512-HH/8nOEmrrcRGHMqJR91FOwhnLlx5SRLXmsQwZT3IPcBjx88WT+0pWC5A4tDOYDdoooh9k+KMPvWfxooR5TcOA==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-16.0.1.tgz",
+      "integrity": "sha512-Wu3dw5aDJmOGw8WjH1I1/yTH+vlXEL4vmjk5p+MHxP8HuHJS1lAGeIdG/hze1AvNeXWo/JgULV87LyQOr+r5jw==",
       "requires": {
-        "dnd-core": "15.1.2"
-      },
-      "dependencies": {
-        "@react-dnd/asap": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/@react-dnd/asap/-/asap-4.0.1.tgz",
-          "integrity": "sha512-kLy0PJDDwvwwTXxqTFNAAllPHD73AycE9ypWeln/IguoGBEbvFcPDbCV03G52bEcC5E+YgupBE0VzHGdC8SIXg=="
-        },
-        "@react-dnd/invariant": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/@react-dnd/invariant/-/invariant-3.0.1.tgz",
-          "integrity": "sha512-blqduwV86oiKw2Gr44wbe3pj3Z/OsXirc7ybCv9F/pLAR+Aih8F3rjeJzK0ANgtYKv5lCpkGVoZAeKitKDaD/g=="
-        },
-        "dnd-core": {
-          "version": "15.1.2",
-          "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-15.1.2.tgz",
-          "integrity": "sha512-EOec1LyJUuGRFg0LDa55rSRAUe97uNVKVkUo8iyvzQlcECYTuPblVQfRWXWj1OyPseFIeebWpNmKFy0h6BcF1A==",
-          "requires": {
-            "@react-dnd/asap": "4.0.1",
-            "@react-dnd/invariant": "3.0.1",
-            "redux": "^4.1.2"
-          }
-        }
+        "dnd-core": "^16.0.1"
       }
     },
     "react-dom": {

--- a/src/workspaces/cookiefactoryv2/CookieFactoryDemo/package.json
+++ b/src/workspaces/cookiefactoryv2/CookieFactoryDemo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@amzn/cookie-factory-demo-v2",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.2.0",
   "type": "module",
   "scripts": {
     "dev": "webpack serve --config webpack.dev.js",
@@ -11,9 +11,9 @@
     "@aws-sdk/client-cognito-identity": "3.252.0",
     "@aws-sdk/client-iottwinmaker": "3.252.0",
     "@aws-sdk/credential-provider-cognito-identity": "3.252.0",
-    "@iot-app-kit/react-components": "5.5.1",
-    "@iot-app-kit/scene-composer": "5.5.1",
-    "@iot-app-kit/source-iottwinmaker": "5.5.1",
+    "@iot-app-kit/react-components": "5.7.0",
+    "@iot-app-kit/scene-composer": "5.7.0",
+    "@iot-app-kit/source-iottwinmaker": "5.7.0",
     "amazon-cognito-identity-js": "6.1.2",
     "cytoscape": "3.23.0",
     "immer": "9.0.19",


### PR DESCRIPTION
Bump @iot-app-kit dependencies from 5.5.1 to 5.7.0, fixes SceneViewer unmount bug.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
