### PR TITLE
Removed hard-coded us-east-1 region in Cognito CDK setup

### DIFF
--- a/src/workspaces/cookiefactoryv2/cdk/lib/cookiefactory_v2_stack.ts
+++ b/src/workspaces/cookiefactoryv2/cdk/lib/cookiefactory_v2_stack.ts
@@ -458,8 +458,8 @@ export class CookieFactoryV2Stack extends cdk.Stack {
                     "iottwinmaker:GetComponentType"],
                 effect: iam.Effect.ALLOW,
                 resources: [
-                    `arn:aws:iottwinmaker:us-east-1:${this.account}:workspace/${workspaceId}/*`,
-                    `arn:aws:iottwinmaker:us-east-1:${this.account}:workspace/${workspaceId}`
+                    `arn:aws:iottwinmaker:${this.region}:${this.account}:workspace/${workspaceId}/*`,
+                    `arn:aws:iottwinmaker:${this.region}:${this.account}:workspace/${workspaceId}`
                 ],
             })
         );


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
