### PR TITLE
fix(scene_utils): ignore dataBindingConfig in scene properties if empty

### DIFF
--- a/src/libs/scene_utils/utils/deserializer.ts
+++ b/src/libs/scene_utils/utils/deserializer.ts
@@ -352,10 +352,20 @@ export class Deserializer {
     if (!propertiesJson) {
       return {};
     }
-    return {
+    let properties: SceneProperties = {
       environmentPreset: propertiesJson['environmentPreset'],
-      dataBindingConfig: this.deserializeSceneDataBindingConfig(propertiesJson['dataBindingConfig']),
     };
+
+    // Don't add dataBindingConfig property if no content
+    const dataBindingConfig = propertiesJson['dataBindingConfig'];
+    if (!!dataBindingConfig) {
+      properties = {
+        ...properties,
+        dataBindingConfig: this.deserializeSceneDataBindingConfig(propertiesJson['dataBindingConfig']),
+      }
+    }
+
+    return properties;
   }
 
   private deserializeSceneDataBindingConfig(sceneDataBindingConfig: JSON): DataBindingConfig {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When loading a scene with an empty `dataBindingConfig` in its `properties`, there was a bug that broke interaction with elements in the scene. When you click on a Tag in the Scene Composer the Inspector panel is empty, and causes all other selections in the object hierarchy to have an empty Inspector panel.

Need to ignore `dataBindingConfig` if it is empty.

Tested by running the Cesium script example and saw things work normally in the Scene Composer.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
