### PR TITLE
Updated opencv python dependency to 4.10.0.84 to resolve a Lambda function deployment error

### DIFF
--- a/src/libs/opencv_utils/requirements.txt
+++ b/src/libs/opencv_utils/requirements.txt
@@ -1,3 +1,3 @@
-opencv-python-headless==4.9.0.80
+opencv-python-headless==4.10.0.84
 requests==2.31.0
 urllib3<2


### PR DESCRIPTION
…ction deployment failure. Fixes issue #159.

*Issue #, if available:*
Issue #159

*Description of changes:*

Updated opencv-python-headless to 4.10.0.84
