### PR TITLE
Switched to an auto-generated password for cognito admin

### DIFF
--- a/src/workspaces/cookiefactoryv3/dashboard/install.sh
+++ b/src/workspaces/cookiefactoryv3/dashboard/install.sh
@@ -48,7 +48,7 @@ sed_cmd "s/region: '__FILL_IN__'/region: '${AWS_DEFAULT_REGION}'/" src/app.confi
 COGNITO_USER_POOL_ID=$(echo $CFN_STACK_OUTPUTS | jq -r '.[] | select(.OutputKey=="UserPoolId").OutputValue')
 sed_cmd "s/userPoolId: '__FILL_IN__'/userPoolId: '${COGNITO_USER_POOL_ID}'/" src/app.config.tsx 
 
-COGNITO_PASSWORD="Aa#45678"
+COGNITO_PASSWORD=$(aws secretsmanager get-random-password --require-each-included-type --password-length 8 --output text)
 sed_cmd "s/password: '__FILL_IN__'/password: '${COGNITO_PASSWORD}'/" src/app.config.tsx 
 
 aws cognito-idp admin-set-user-password --user-pool-id ${COGNITO_USER_POOL_ID} --username "user@cookiefactory" --password "${COGNITO_PASSWORD}" --permanent


### PR DESCRIPTION
*Issue #: https://t.corp.amazon.com/V1505872818

*Description of changes:*

The Cognito admin password was previously set to a static value for every instance of the CookieFactoryv3 demo. 

This has now been updated to use the "aws secretsmanager get-random-password" command to generate a new admin password for every deployment. 